### PR TITLE
Redesign /topics/ page with Stitch section-design

### DIFF
--- a/docs/ai-developer/plans/active/PLAN-topics-redesign.md
+++ b/docs/ai-developer/plans/active/PLAN-topics-redesign.md
@@ -1,0 +1,98 @@
+# Feature: Redesign /topics/ page to match Stitch design
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active
+
+**Goal**: Redesign the topics list page to use the section-design (Stitch) treatment matching personas, blog, and publications pages.
+
+**Last Updated**: 2026-04-07
+
+---
+
+## Overview
+
+The `/topics/` list page still uses the old layout (`section-header.html` + DaisyUI stats widget + DaisyUI card grid). The personas, blog, and publications pages have been migrated to the Stitch section-design pattern with gradient hero, stat cards, and styled card layouts. This plan brings topics in line with those pages.
+
+The topics page currently filters to only show topics with content. This behavior should be preserved. Topics data comes from `data/topics/topics.json`. Topics is a Hugo taxonomy (`topic = "topics"` in `hugo.toml`).
+
+**Reference**: The completed personas redesign at `docs/ai-developer/plans/completed/PLAN-personas-redesign.md` is the template. The new personas layout at `layouts/personas/list.html` shows the target pattern.
+
+---
+
+## Current State
+
+- **Topics list** (`layouts/topics/list.html`): Uses `section-header.html` partial, DaisyUI `stats` widget, DaisyUI `card` classes with Tailwind grid. Counts content per topic and only shows topics with content.
+- **Personas list** (`layouts/personas/list.html`): Full Stitch design — gradient hero, 3 stat cards, featured persona + grid layout.
+- **Data source**: `data/topics/topics.json` has 25 topics with identifiers, names, descriptions, and icons.
+
+---
+
+## Phase 1: Redesign Topics List Template — DONE
+
+### Tasks
+
+- [x] 1.1 Replace `section-header.html` with Stitch gradient hero section (`sd-events-hero` pattern)
+  - Badge text: "Content Library"
+  - Title: "Topics"
+  - Description: from page `.Description` or fallback text about browsing content by topic
+- [x] 1.2 Add stat cards section (`sd-events-stats` pattern) with 3 stats:
+  - Topics count (topics with content)
+  - Tagged Content count (total tagged items across all topics)
+  - Blog Posts count (all blog posts)
+- [x] 1.3 Redesign card grid to match Stitch card pattern
+  - Use `sd-blog-featured` + `sd-blog-card` / `sd-blog-grid` pattern classes
+  - First topic (with content) is featured (large), rest in grid
+  - Each card: topic icon (via `data-icon.html`), name, description
+  - Cards link to `/topics/{identifier}/`
+  - Preserve content count badge on each card
+- [x] 1.4 Add "no results" message for empty state
+- [x] 1.5 Preserve existing content-counting logic (only show topics with content)
+- [x] 1.6 Add footer partial (`sovereignsky-footer.html`)
+
+### Validation
+
+- Hugo builds without errors
+- Topics list page shows gradient hero, stat cards, and styled cards
+- Only topics with content are displayed
+- Content count badges are preserved on each card
+
+---
+
+## Phase 2: Visual QA and Polish — NEEDS USER VERIFICATION
+
+### Tasks
+
+- [x] 2.1 Verify dark mode styling on all new elements (uses same sd-* classes as personas — verified by code review)
+- [x] 2.2 Verify responsive layout (uses same sd-blog-grid as personas — verified by code review)
+- [x] 2.3 Ensure topic card icons render correctly (uses data-icon.html partial with icon field from topics.json)
+- [ ] 2.4 Verify links to individual topic pages work (needs Hugo build)
+
+### Validation
+
+User confirms visual quality matches personas/blog/publications pages.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Topics list page uses Stitch section-design pattern (hero, stats, cards)
+- [ ] Content count badges preserved on topic cards
+- [ ] Only topics with content are displayed
+- [ ] Dark mode works correctly
+- [ ] Responsive layout works on mobile/tablet/desktop
+- [ ] Hugo builds without errors
+
+---
+
+## Files to Modify
+
+- `layouts/topics/list.html` — Full rewrite to Stitch design pattern
+
+## Reference Files (read-only)
+
+- `layouts/personas/list.html` — Primary design reference
+- `layouts/blog/list.html` — Secondary design reference
+- `data/topics/topics.json` — Topics data source

--- a/layouts/topics/list.html
+++ b/layouts/topics/list.html
@@ -27,80 +27,152 @@
   {{ end }}
 {{ end }}
 
-<article class="max-w-full">
-  {{/* Section Header */}}
-  {{ partial "section-header.html" (dict
-      "title" "Content by Topic"
-      "description" "Browse all content organized by topic. Each topic page shows all blogs, events, publications, and laws related to that subject."
-      "icon" "tag"
-  ) }}
+{{/* Calculate stats */}}
+{{ $totalTopics := len $topicsWithContent }}
+{{ $totalContent := 0 }}
+{{ range $topicsWithContent }}
+  {{ $totalContent = add $totalContent (index $contentCounts .identifier | default 0) }}
+{{ end }}
+{{ $totalBlogPosts := len (where site.RegularPages "Section" "blog") }}
 
-  {{/* Stats */}}
-  {{ $totalTopics := len $topicsWithContent }}
-  {{ $totalContent := 0 }}
-  {{ range $topicsWithContent }}
-    {{ $totalContent = add $totalContent (index $contentCounts .identifier | default 0) }}
-  {{ end }}
+<article class="sd-topics section-design">
 
-  <div class="stats stats-vertical sm:stats-horizontal shadow-lg w-full mb-8 bg-base-100">
-    <div class="stat">
-      <div class="stat-figure text-primary">
-        {{ partial "data-icon.html" (dict "name" "tag" "color" "primary" "size" "8") }}
+  {{/* ============================================================
+       HERO — Blue gradient
+       ============================================================ */}}
+  <section class="sd-events-hero">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Content Library</span>
+        </div>
+        <h1 class="sd-headline sd-events-hero-title">Topics</h1>
+        <p class="sd-events-hero-description">
+          {{ .Description | default "Browse all content organized by topic. Each topic page shows all blogs, events, publications, and laws related to that subject." }}
+        </p>
       </div>
-      <div class="stat-title">Topics</div>
-      <div class="stat-value text-primary">{{ $totalTopics }}</div>
-      <div class="stat-desc">With content</div>
     </div>
-    <div class="stat">
-      <div class="stat-figure text-secondary">
-        {{ partial "data-icon.html" (dict "name" "document" "color" "secondary" "size" "8") }}
-      </div>
-      <div class="stat-title">Tagged Content</div>
-      <div class="stat-value text-secondary">{{ $totalContent }}</div>
-      <div class="stat-desc">Across all topics</div>
-    </div>
-  </div>
+  </section>
 
-  {{/* Topics Cards Grid */}}
-  <section class="mt-8">
+  {{/* ============================================================
+       STATS — 3 cards overlapping hero
+       ============================================================ */}}
+  <section class="sd-events-stats">
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Topics</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $totalTopics }}</span>
+        <span class="sd-events-stat-desc">With content</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Tagged Content</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $totalContent }}</span>
+        <span class="sd-events-stat-desc">Across all topics</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Blog Posts</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $totalBlogPosts }}</span>
+        <span class="sd-events-stat-desc">Articles published</span>
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       TOPIC CARDS — Featured + Grid
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+
     {{ if gt (len $topicsWithContent) 0 }}
-    <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {{ range $topicsWithContent }}
-        {{ $t := . }}
-        {{ $term := $t.identifier | default "" }}
-        {{ $name := $t.name | default ($term | humanize | title) }}
-        {{ $desc := $t.description | default "" }}
-        {{ $iconPath := $t.iconPath | default "" }}
-        {{ $count := index $contentCounts $term | default 0 }}
 
-        <a href="/topics/{{ $term }}/" class="card card-compact bg-base-100 shadow-sm hover:shadow-md transition-all group border border-base-200 hover:border-primary">
-          <div class="card-body">
-            {{/* Title with icon */}}
-            <div class="flex items-center justify-between">
-              <div class="flex items-center gap-2">
-                {{ if $iconPath }}
-                <div class="text-primary">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="{{ $iconPath }}"/>
-                  </svg>
-                </div>
-                {{ end }}
-                <h2 class="card-title text-sm group-hover:text-primary transition-colors m-0">{{ $name }}</h2>
-              </div>
-              <span class="badge badge-primary badge-sm">{{ $count }}</span>
-            </div>
+    {{ range $i, $t := $topicsWithContent }}
+    {{ $term := $t.identifier | default "" }}
+    {{ $name := $t.name | default ($term | humanize | title) }}
+    {{ $desc := $t.description | default "" }}
+    {{ $icon := $t.icon | default "" }}
+    {{ $count := index $contentCounts $term | default 0 }}
 
-            {{/* Description */}}
-            {{ if $desc }}
-            <p class="text-xs text-neutral-600 dark:text-neutral-400 line-clamp-2 mt-1 mb-0">{{ $desc }}</p>
+    {{ if eq $i 0 }}
+    {{/* ---- FEATURED TOPIC (first) ---- */}}
+    <article class="sd-blog-featured">
+      <a href="/topics/{{ $term }}/" class="sd-blog-featured-inner">
+        <div class="sd-blog-featured-image">
+          <div class="sd-blog-featured-placeholder">
+            {{ if $icon }}
+            {{ partial "data-icon.html" (dict "name" $icon "size" "16" "class" "text-primary") }}
+            {{ else }}
+            <span class="material-symbols-outlined" style="font-size: 4rem; color: var(--sd-primary); opacity: 0.3;">tag</span>
             {{ end }}
           </div>
-        </a>
-      {{ end }}
+        </div>
+        <div class="sd-blog-featured-content">
+          <div style="display: flex; align-items: center; gap: 0.75rem;">
+            <h2 class="sd-headline sd-blog-featured-title" style="margin: 0;">{{ $name }}</h2>
+            <span class="badge badge-primary badge-sm">{{ $count }}</span>
+          </div>
+          {{ with $desc }}
+          <p class="sd-blog-featured-desc">{{ . }}</p>
+          {{ end }}
+          <span class="sd-blog-read-more">
+            Browse Topic
+            <span class="material-symbols-outlined" style="font-size: 0.875rem;">arrow_forward</span>
+          </span>
+        </div>
+      </a>
+    </article>
+
+    {{ else }}
+
+    {{ if eq $i 1 }}
+    {{/* Open the grid after featured card */}}
+    <div class="sd-blog-grid">
+    {{ end }}
+
+    {{/* ---- REGULAR TOPIC CARD ---- */}}
+    <article class="sd-blog-card">
+      <a href="/topics/{{ $term }}/" class="sd-blog-card-inner">
+        <div class="sd-blog-card-image">
+          <div class="sd-blog-featured-placeholder">
+            {{ if $icon }}
+            {{ partial "data-icon.html" (dict "name" $icon "size" "12" "class" "text-primary") }}
+            {{ else }}
+            <span class="material-symbols-outlined" style="font-size: 3rem; color: var(--sd-primary); opacity: 0.3;">tag</span>
+            {{ end }}
+          </div>
+        </div>
+        <div class="sd-blog-card-content">
+          <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <h3 class="sd-headline sd-blog-card-title" style="margin: 0;">{{ $name }}</h3>
+            <span class="badge badge-primary badge-sm">{{ $count }}</span>
+          </div>
+          {{ with $desc }}
+          <p class="sd-blog-card-desc">{{ . }}</p>
+          {{ end }}
+        </div>
+      </a>
+    </article>
+
+    {{ if eq $i (sub (len $topicsWithContent) 1) }}
+    {{/* Close the grid after last card */}}
     </div>
+    {{ end }}
+
+    {{ end }}
+    {{ end }}
+
     {{ else }}
     <p class="text-neutral-600 dark:text-neutral-400">No topics with content found.</p>
     {{ end }}
+
   </section>
+
 </article>
+
+{{ partial "sovereignsky-footer.html" . }}
+
 {{ end }}


### PR DESCRIPTION
## Summary

- Replace old `section-header.html` + DaisyUI stats/card layout with Stitch section-design pattern
- Add gradient hero, 3 stat cards (Topics, Tagged Content, Blog Posts), and featured+grid card layout
- Preserve content-counting logic — only topics with content are shown, each card has a count badge
- Follows the same pattern as the completed personas redesign

## Reference

- Matches `layouts/personas/list.html` design pattern
- Plan: `docs/ai-developer/plans/active/PLAN-topics-redesign.md`

## Test plan

- [ ] Hugo builds without errors
- [ ] Topics page shows gradient hero with "Content Library" badge
- [ ] 3 stat cards display correctly
- [ ] Featured topic card (first) renders with large layout
- [ ] Remaining topic cards render in grid
- [ ] Count badges appear on all cards
- [ ] Dark mode renders correctly
- [ ] Responsive layout works on mobile/tablet/desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)