### PR TITLE
Redesign networks and countries pages to Stitch section-design system

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3109,6 +3109,35 @@ details[open] .details-marker {
   padding: 0;
 }
 
+/* Bloc page — 4-column stats grid */
+.sd-bloc-stats {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .sd-bloc-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .sd-bloc-stats {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+/* Bloc info note */
+.sd-bloc-note {
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--sd-outline-variant);
+  background-color: var(--sd-surface-container-low);
+  color: var(--sd-on-surface-variant);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  margin-bottom: 1.5rem;
+}
+
 /* Network data tables */
 .sd-network-tables {
   display: flex;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2997,3 +2997,24 @@ details[open] .details-marker {
     grid-template-columns: repeat(4, 1fr);
   }
 }
+
+/* Networks detail page — 3-column metadata grid */
+.sd-network-detail-meta {
+  grid-template-columns: 1fr !important;
+}
+
+@media (min-width: 768px) {
+  .sd-network-detail-meta {
+    grid-template-columns: repeat(3, 1fr) !important;
+  }
+}
+
+.sd-network-detail-meta .sd-events-stat-card dl {
+  margin: 0;
+}
+
+.sd-network-detail-meta .sd-events-stat-card dt,
+.sd-network-detail-meta .sd-events-stat-card dd {
+  margin: 0;
+  padding: 0;
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3088,6 +3088,27 @@ details[open] .details-marker {
   color: var(--sd-on-surface-variant);
 }
 
+/* Countries detail page — 3-column metadata grid */
+.sd-country-detail-meta {
+  grid-template-columns: 1fr !important;
+}
+
+@media (min-width: 768px) {
+  .sd-country-detail-meta {
+    grid-template-columns: repeat(3, 1fr) !important;
+  }
+}
+
+.sd-country-detail-meta .sd-events-stat-card dl {
+  margin: 0;
+}
+
+.sd-country-detail-meta .sd-events-stat-card dt,
+.sd-country-detail-meta .sd-events-stat-card dd {
+  margin: 0;
+  padding: 0;
+}
+
 /* Network data tables */
 .sd-network-tables {
   display: flex;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3018,3 +3018,227 @@ details[open] .details-marker {
   margin: 0;
   padding: 0;
 }
+
+/* Network data tables */
+.sd-network-tables {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.sd-network-tables section h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  font-family: 'Space Grotesk', sans-serif;
+  color: var(--sd-on-surface);
+  margin: 0 0 0.5rem;
+}
+
+.sd-network-section-desc {
+  font-size: 0.875rem;
+  color: var(--sd-on-surface-variant);
+  margin: 0 0 0.75rem;
+  line-height: 1.5;
+}
+
+.sd-network-section-desc a {
+  color: var(--sd-primary);
+  text-decoration: underline;
+}
+
+.sd-table-wrap {
+  overflow-x: auto;
+}
+
+.sd-network-tables table {
+  text-align: left;
+}
+
+.sd-network-tables table td:not(:first-child),
+.sd-network-tables table th:not(:first-child) {
+  text-align: left;
+}
+
+.sd-network-tables table td:first-child {
+  font-weight: 500;
+}
+
+.sd-network-tables table td:first-child a {
+  color: var(--sd-primary);
+  text-decoration: none;
+}
+
+.sd-network-tables table td:first-child a:hover {
+  text-decoration: underline;
+}
+
+.sd-network-count {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--sd-outline);
+}
+
+/* Status badges (replacing DaisyUI badge classes) */
+.sd-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.sd-status-active {
+  background-color: rgba(0, 108, 73, 0.1);
+  color: var(--sd-secondary);
+}
+
+.dark .sd-status-active {
+  background-color: rgba(108, 248, 187, 0.15);
+  color: var(--sd-secondary-container);
+}
+
+.sd-status-planned {
+  background-color: rgba(245, 158, 11, 0.1);
+  color: #b45309;
+}
+
+.dark .sd-status-planned {
+  background-color: rgba(245, 158, 11, 0.15);
+  color: #fbbf24;
+}
+
+/* Network map filter panel */
+.sd-network-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  padding: 1.25rem;
+  background-color: var(--sd-surface-container-low);
+  border-radius: 0.75rem;
+  border: 1px solid var(--sd-outline-variant);
+}
+
+.sd-network-filter-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sd-network-filter-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--sd-on-surface-variant);
+  min-width: 3.5rem;
+}
+
+.sd-network-checkboxes {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sd-network-checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  color: var(--sd-on-surface-variant);
+}
+
+.sd-network-checkbox {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.sd-network-checkbox-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Network map container */
+.sd-network-map-container {
+  width: 100%;
+  height: 700px;
+  background-color: var(--sd-surface-container-low);
+  border-radius: 0.75rem;
+  border: 1px solid var(--sd-outline-variant);
+}
+
+.sd-network-map-loading {
+  text-align: center;
+  padding: 2rem 0;
+  color: var(--sd-outline);
+}
+
+/* Network details panel */
+.sd-network-details {
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+  background-color: var(--sd-surface-container-low);
+  border-radius: 0.75rem;
+  border: 1px solid var(--sd-outline-variant);
+}
+
+.sd-network-details-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  font-family: 'Space Grotesk', sans-serif;
+  color: var(--sd-on-surface);
+  margin: 0 0 0.5rem;
+}
+
+.sd-network-details-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+  line-height: 1.3;
+}
+
+.sd-network-details-link {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--sd-primary);
+  white-space: nowrap;
+}
+
+.sd-network-details-link:hover {
+  text-decoration: underline;
+}
+
+.sd-network-details-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sd-network-details-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sd-network-details-meta-item {
+  font-size: 0.75rem;
+  color: var(--sd-on-surface-variant);
+}
+
+.sd-network-details-endpoints {
+  font-size: 0.875rem;
+  color: var(--sd-on-surface);
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3019,6 +3019,75 @@ details[open] .details-marker {
   padding: 0;
 }
 
+/* Countries section-design — 3-column stats grid */
+.sd-countries-stats {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .sd-countries-stats {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Countries grid */
+.sd-country-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+@media (min-width: 640px) {
+  .sd-country-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 768px) {
+  .sd-country-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .sd-country-grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
+}
+
+.sd-country-card {
+  display: block;
+  padding: 0.625rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--sd-outline-variant, #e5e7eb);
+  background: var(--sd-surface-container-low, #fff);
+  text-decoration: none;
+  color: var(--sd-on-surface);
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.sd-country-card:hover {
+  border-color: var(--sd-primary);
+  background: var(--sd-surface-container, #f9fafb);
+}
+
+.sd-country-card-name {
+  font-size: 0.875rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sd-country-card-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  margin-top: 0.375rem;
+  font-size: 0.75rem;
+  color: var(--sd-on-surface-variant);
+}
+
 /* Network data tables */
 .sd-network-tables {
   display: flex;

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2980,3 +2980,20 @@ details[open] .details-marker {
   border-color: var(--sd-outline-variant);
   margin: 2rem 0;
 }
+
+/* Networks section-design — 4-column stats grid */
+.sd-networks .sd-events-stats {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .sd-networks .sd-events-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .sd-networks .sd-events-stats {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/content/countries/_index.md
+++ b/content/countries/_index.md
@@ -13,7 +13,3 @@ Explore countries and regional blocs by their data sovereignty characteristics, 
 Regional blocs share common legal frameworks and data protection standards across their member countries.
 
 {{< bloc-cards >}}
-
-## Browse by Country
-
-Individual countries with datacenter infrastructure, showing their risk level and bloc memberships.

--- a/layouts/countries/bloc.html
+++ b/layouts/countries/bloc.html
@@ -28,6 +28,15 @@
   {{ $blocFlag := $bloc.flag | default "" }}
   {{ $riskLevel := $bloc.riskLevel | default "unknown" }}
 
+  {{/* Risk emoji */}}
+  {{ $riskEmoji := "❓" }}
+  {{ if eq $riskLevel "low" }}{{ $riskEmoji = "✅" }}
+  {{ else if eq $riskLevel "moderate" }}{{ $riskEmoji = "⚠️" }}
+  {{ else if eq $riskLevel "elevated" }}{{ $riskEmoji = "⚠️" }}
+  {{ else if eq $riskLevel "high" }}{{ $riskEmoji = "🚨" }}
+  {{ else if eq $riskLevel "sanctioned" }}{{ $riskEmoji = "🚫" }}
+  {{ end }}
+
   {{/* Build lookup for blocs by id */}}
   {{ $blocsById := dict }}
   {{ range $blocsData }}
@@ -50,7 +59,6 @@
           {{ $allMembers = $allMembers | append . }}
         {{ end }}
       {{ end }}
-      {{/* Go one more level for grandparent inheritance */}}
       {{ range ($parentBloc.inheritsFrom | default (slice)) }}
         {{ $grandparent := index $blocsById . }}
         {{ if $grandparent }}
@@ -113,144 +121,136 @@
   {{/* Build comma-separated list of all member country IDs for map */}}
   {{ $allMemberIds := delimit $allMembers "," }}
 
-  <article class="max-w-full">
-    {{/* Detail Header with breadcrumbs */}}
-    {{ partial "common-detail-header.html" (dict
-        "title" $blocName
-        "description" ($bloc.summary | default $bloc.description | default "")
-        "flag" $blocFlag
-        "breadcrumbs" (slice
-            (dict "title" "Countries" "url" "/countries/")
-        )
-    ) }}
+<article class="sd-countries section-design">
 
-    {{/* Stats Row */}}
-    <div class="stats stats-vertical sm:stats-horizontal shadow-lg w-full mb-8 bg-base-100">
-      {{/* Risk Level */}}
-      <div class="stat">
-        <div class="stat-figure">
-          {{ if eq $riskLevel "low" }}
-          <span class="text-success text-3xl">✅</span>
-          {{ else if eq $riskLevel "moderate" }}
-          <span class="text-warning text-3xl">⚠️</span>
-          {{ else if eq $riskLevel "elevated" }}
-          <span class="text-warning text-3xl">⚠️</span>
-          {{ else if eq $riskLevel "high" }}
-          <span class="text-error text-3xl">🚨</span>
-          {{ else if eq $riskLevel "sanctioned" }}
-          <span class="text-error text-3xl">🚫</span>
-          {{ else }}
-          <span class="text-neutral text-3xl">❓</span>
-          {{ end }}
-        </div>
-        <div class="stat-title">Risk Level</div>
-        <div class="stat-value text-xl {{ if eq $riskLevel "low" }}text-success{{ else if eq $riskLevel "moderate" }}text-warning{{ else if eq $riskLevel "elevated" }}text-warning{{ else if eq $riskLevel "high" }}text-error{{ else if eq $riskLevel "sanctioned" }}text-error{{ end }}">
-          {{ $riskLevel | title }}
-        </div>
-        <div class="stat-desc">Data sovereignty</div>
-      </div>
+  {{/* ============================================================
+       HERO — Compact detail hero with breadcrumbs
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/countries/" style="color: inherit; text-decoration: none; opacity: 0.7;">Countries</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ $blocName }}</span>
+          </span>
+        </nav>
 
-      {{/* Member Countries */}}
-      <div class="stat">
-        <div class="stat-figure text-accent">
-          {{ partial "data-icon.html" (dict "name" "globe" "color" "accent" "size" "8") }}
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Regional Bloc</span>
         </div>
-        <div class="stat-title">Member Countries</div>
-        <div class="stat-value text-accent">{{ $memberCount }}</div>
-        <div class="stat-desc">{{ if gt (len $directMembers) 0 }}{{ len $directMembers }} direct{{ if gt (len ($bloc.inheritsFrom | default (slice))) 0 }}, {{ sub $memberCount (len $directMembers) }} inherited{{ end }}{{ else }}All inherited{{ end }}</div>
-      </div>
 
-      {{/* Laws */}}
-      <div class="stat">
-        <div class="stat-figure text-primary">
-          {{ partial "data-icon.html" (dict "name" "scale" "color" "primary" "size" "8") }}
-        </div>
-        <div class="stat-title">Applicable Laws</div>
-        <div class="stat-value text-primary">{{ $lawCount }}</div>
-        <div class="stat-desc">Privacy, access & security</div>
-      </div>
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">
+          {{ if $blocFlag }}<span style="margin-right: 0.5rem;">{{ $blocFlag }}</span>{{ end }}{{ $blocName }}
+        </h1>
 
-      {{/* Datacenters */}}
-      <div class="stat">
-        <div class="stat-figure text-secondary">
-          {{ partial "data-icon.html" (dict "name" "server" "color" "secondary" "size" "8") }}
-        </div>
-        <div class="stat-title">Datacenter Regions</div>
-        <div class="stat-value text-secondary">{{ $datacenterCount }}</div>
-        <div class="stat-desc">Across member countries</div>
+        {{ with ($bloc.summary | default $bloc.description | default "") }}
+        <p class="sd-events-hero-description">{{ . }}</p>
+        {{ end }}
       </div>
     </div>
+  </section>
 
-    {{/* Summary */}}
-    {{ with .Params.summary }}
-    <div class="prose dark:prose-invert max-w-none mb-8">
-      <p class="lead text-lg text-neutral-600 dark:text-neutral-400">{{ . }}</p>
-    </div>
-    {{ end }}
-
-    {{/* Notes */}}
-    {{ with $bloc.notes }}
-    <div class="alert alert-info mb-8">
-      <svg class="w-6 h-6 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-      </svg>
-      <div>
-        <h3 class="font-bold">Note</h3>
-        <p class="text-sm">{{ . }}</p>
+  {{/* ============================================================
+       STATS — 4 cards overlapping hero
+       ============================================================ */}}
+  <section class="sd-events-stats sd-bloc-stats">
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Risk Level</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value-text">{{ $riskEmoji }} {{ $riskLevel | title }}</span>
+        <span class="sd-events-stat-desc">Data sovereignty</span>
       </div>
     </div>
-    {{ end }}
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Member Countries</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $memberCount }}</span>
+        <span class="sd-events-stat-desc">{{ if gt (len $directMembers) 0 }}{{ len $directMembers }} direct{{ if gt (len ($bloc.inheritsFrom | default (slice))) 0 }}, {{ sub $memberCount (len $directMembers) }} inherited{{ end }}{{ else }}All inherited{{ end }}</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Applicable Laws</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $lawCount }}</span>
+        <span class="sd-events-stat-desc">Privacy, access & security</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Datacenter Regions</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $datacenterCount }}</span>
+        <span class="sd-events-stat-desc">Across member countries</span>
+      </div>
+    </div>
+  </section>
 
-    {{/* Inherits From */}}
-    {{ if gt (len ($bloc.inheritsFrom | default (slice))) 0 }}
-    <div class="mb-8">
-      <h2 class="text-xl font-bold text-neutral-800 dark:text-neutral-100 mb-4">Inherits From</h2>
-      <div class="flex flex-wrap gap-2">
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* Summary */}}
+      {{ with .Params.summary }}
+      <p style="font-size: 1.125rem; color: var(--sd-on-surface-variant); line-height: 1.7; margin-bottom: 1.5rem;">{{ . }}</p>
+      {{ end }}
+
+      {{/* Notes */}}
+      {{ with $bloc.notes }}
+      <div class="sd-bloc-note">
+        <strong>Note:</strong> {{ . }}
+      </div>
+      {{ end }}
+
+      {{/* Inherits From */}}
+      {{ if gt (len ($bloc.inheritsFrom | default (slice))) 0 }}
+      <h2 id="inherits">Inherits From</h2>
+      <div class="sd-filter-pills">
         {{ range ($bloc.inheritsFrom | default (slice)) }}
           {{ $parent := index $blocsById . }}
           {{ if $parent }}
-          <a href="/countries/{{ $parent.slug }}/" class="btn btn-outline btn-sm gap-2">
-            <span>{{ $parent.flag }}</span>
-            <span>{{ $parent.name }}</span>
+          <a href="/countries/{{ $parent.slug }}/" class="sd-filter-pill" style="text-decoration: none;">
+            {{ with $parent.flag }}{{ . }} {{ end }}{{ $parent.name }}
           </a>
           {{ end }}
         {{ end }}
       </div>
-    </div>
-    {{ end }}
+      {{ end }}
 
-    {{/* Map of Member Countries with Datacenters */}}
-    {{ if gt (len $directMembers) 0 }}
-    <div class="mb-8">
-      <h2 class="text-2xl font-bold text-neutral-800 dark:text-neutral-100 mb-2" id="map">Datacenters in {{ $blocName }}</h2>
-      <p class="text-neutral-600 dark:text-neutral-400 mb-4">
+      {{/* Map of Member Countries with Datacenters */}}
+      {{ if gt (len $directMembers) 0 }}
+      <h2 id="map">Datacenters in {{ $blocName }}</h2>
+      <p style="color: var(--sd-on-surface-variant); margin-bottom: 1rem;">
         Datacenter locations across {{ $memberCount }} member countries.
       </p>
-      {{ $mapShortcode := printf "{{< datacenter-map countries=\"%s\" showFilters=\"false\" >}}" $allMemberIds }}
-      {{ $mapShortcode | $.RenderString }}
-    </div>
-    {{ end }}
+      <div class="not-prose">
+        {{ $mapShortcode := printf "{{< datacenter-map countries=\"%s\" showFilters=\"false\" >}}" $allMemberIds }}
+        {{ $mapShortcode | $.RenderString }}
+      </div>
+      {{ end }}
 
-    {{/* Applicable Laws - use shared partial */}}
-    {{ if gt $lawCount 0 }}
-    <div class="mb-8">
-      <h2 class="text-2xl font-bold text-neutral-800 dark:text-neutral-100 mb-2" id="laws">Applicable Laws</h2>
-      <p class="text-neutral-600 dark:text-neutral-400 mb-6">
+      {{/* Applicable Laws */}}
+      {{ if gt $lawCount 0 }}
+      <h2 id="laws">Applicable Laws</h2>
+      <p style="color: var(--sd-on-surface-variant); margin-bottom: 1.5rem;">
         {{ $lawCount }} laws and regulations apply to {{ $blocName }}.
       </p>
       {{ partial "jurisdiction-laws-inline.html" (dict "jurisdictionId" $blocId) }}
-    </div>
-    {{ end }}
+      {{ end }}
 
-    {{/* Member Countries Grid */}}
-    {{ if gt $memberCount 0 }}
-    <div class="mb-8">
-      <h2 class="text-2xl font-bold text-neutral-800 dark:text-neutral-100 mb-2" id="members">Member Countries</h2>
-      <p class="text-neutral-600 dark:text-neutral-400 mb-6">
+      {{/* Member Countries Grid */}}
+      {{ if gt $memberCount 0 }}
+      <h2 id="members">Member Countries</h2>
+      <p style="color: var(--sd-on-surface-variant); margin-bottom: 1.5rem;">
         {{ $memberCount }} countries are part of {{ $blocName }}.
       </p>
 
-      {{/* Build sorted list of member country data */}}
       {{ $countries := site.Data.countries.countries.itemListElement }}
       {{ $memberCountryData := slice }}
       {{ range $allMembers }}
@@ -258,8 +258,6 @@
         {{ $countryMatch := first 1 (where $countries "identifier" $memberId) }}
         {{ with index $countryMatch 0 }}
           {{ $country := . }}
-
-          {{/* Count datacenters for this country */}}
           {{ $countryDcCount := 0 }}
           {{ range (site.Data.datacenters.datacenters | default (slice)) }}
             {{ range (.regions | default (slice)) }}
@@ -268,15 +266,12 @@
               {{ end }}
             {{ end }}
           {{ end }}
-
-          {{/* Count local laws for this country */}}
           {{ $countryLawCount := 0 }}
           {{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
             {{ if in .legislationJurisdiction $memberId }}
               {{ $countryLawCount = add $countryLawCount 1 }}
             {{ end }}
           {{ end }}
-
           {{ $memberCountryData = $memberCountryData | append (dict
             "identifier" $memberId
             "name" $country.name
@@ -288,42 +283,38 @@
         {{ end }}
       {{ end }}
 
-      {{/* Sort by country name */}}
       {{ $memberCountryData = sort $memberCountryData "name" "asc" }}
 
-      <div class="not-prose grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
+      <div class="sd-country-grid">
         {{ range $memberCountryData }}
-        <a href="/countries/{{ .slug }}/" class="block p-2.5 rounded-lg border border-base-200 hover:border-primary/50 hover:bg-base-100 transition-all no-underline">
-          <div class="flex items-center gap-2">
-            <span class="text-lg flex-shrink-0">{{ .flag }}</span>
-            <span class="text-sm font-medium text-base-content truncate">{{ .name }}</span>
+        <a href="/countries/{{ .slug }}/" class="sd-country-card">
+          <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <span style="font-size: 1.25rem; flex-shrink: 0;">{{ .flag }}</span>
+            <span class="sd-country-card-name">{{ .name }}</span>
           </div>
-          <div class="text-xs text-neutral-500 dark:text-neutral-400 mt-1.5 space-y-0.5">
-            <div>Datacenters: {{ .dcCount }}</div>
-            <div>Local laws: {{ .lawCount }}</div>
+          <div class="sd-country-card-meta">
+            <span>{{ .dcCount }} datacenters</span>
+            <span>{{ .lawCount }} laws</span>
           </div>
         </a>
         {{ end }}
       </div>
-    </div>
-    {{ end }}
+      {{ end }}
 
-    {{/* Datacenter Providers in Bloc */}}
-    {{ if gt $datacenterCount 0 }}
-    <div class="mb-8">
-      <h2 class="text-2xl font-bold text-neutral-800 dark:text-neutral-100 mb-2" id="providers">Datacenter Providers in {{ $blocName }}</h2>
-      <p class="text-neutral-600 dark:text-neutral-400 mb-4">
+      {{/* Datacenter Providers in Bloc */}}
+      {{ if gt $datacenterCount 0 }}
+      <h2 id="providers">Datacenter Providers in {{ $blocName }}</h2>
+      <p style="color: var(--sd-on-surface-variant); margin-bottom: 1rem;">
         Providers with datacenter presence across member countries.
       </p>
 
-      {{/* Build provider list with counts in bloc */}}
-      {{ $providersInBloc := slice }}
       {{ $countries := site.Data.countries.countries.itemListElement }}
       {{ $regionsById := dict }}
       {{ range $countries }}
         {{ $regionsById = merge $regionsById (dict .identifier .) }}
       {{ end }}
 
+      {{ $providersInBloc := slice }}
       {{ range (site.Data.datacenters.datacenters | default (slice)) }}
         {{ $provider := . }}
         {{ $countInBloc := 0 }}
@@ -354,11 +345,9 @@
         {{ end }}
       {{ end }}
 
-      {{/* Sort by count desc, then name */}}
       {{ $providersInBloc = sort $providersInBloc "name" "asc" }}
       {{ $providersInBloc = sort $providersInBloc "count" "desc" }}
 
-      {{/* Group by provider type */}}
       {{ $groups := slice
         (dict "key" "hyperscaler" "title" "Hyperscalers")
         (dict "key" "regional_cloud" "title" "Regional Cloud Providers")
@@ -370,67 +359,69 @@
         {{ $title := .title }}
         {{ $items := where $providersInBloc "providerType" $key }}
         {{ if gt (len $items) 0 }}
-        <h3 class="mt-6 mb-4 text-lg font-semibold text-neutral-700 dark:text-neutral-200">{{ $title }}</h3>
-        <div class="not-prose grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
+        <h3>{{ $title }}</h3>
+        <div class="sd-country-grid">
           {{ range $items }}
           {{ $vendor := index $regionsById .vendorCountryId }}
           {{ $flag := "" }}
-          {{ $vendorName := .vendorCountryId }}
           {{ $risk := "unknown" }}
           {{ if $vendor }}
             {{ $flag = $vendor.flag }}
-            {{ $vendorName = $vendor.name }}
             {{ $risk = $vendor.riskLevel }}
           {{ end }}
 
-          {{ $dot := "bg-neutral-400" }}
-          {{ if eq $risk "low" }}{{ $dot = "bg-green-500" }}{{ end }}
-          {{ if eq $risk "moderate" }}{{ $dot = "bg-yellow-500" }}{{ end }}
-          {{ if eq $risk "elevated" }}{{ $dot = "bg-orange-500" }}{{ end }}
-          {{ if eq $risk "high" }}{{ $dot = "bg-red-500" }}{{ end }}
-          {{ if eq $risk "sanctioned" }}{{ $dot = "bg-red-700" }}{{ end }}
+          {{ $dotColor := "var(--sd-outline)" }}
+          {{ if eq $risk "low" }}{{ $dotColor = "#16a34a" }}{{ end }}
+          {{ if eq $risk "moderate" }}{{ $dotColor = "#d97706" }}{{ end }}
+          {{ if eq $risk "elevated" }}{{ $dotColor = "#ea580c" }}{{ end }}
+          {{ if eq $risk "high" }}{{ $dotColor = "#dc2626" }}{{ end }}
+          {{ if eq $risk "sanctioned" }}{{ $dotColor = "#991b1b" }}{{ end }}
 
-          <a href="/datacenters/{{ .identifier }}/" class="block p-2.5 rounded-lg border border-base-200 hover:border-primary/50 hover:bg-base-100 transition-all no-underline">
-            <div class="flex items-center gap-2">
-              <span class="inline-block w-2 h-2 rounded-full {{ $dot }} flex-shrink-0"></span>
-              <span class="text-sm font-medium text-base-content truncate">{{ .name }}</span>
-              {{ if $flag }}<span class="text-sm flex-shrink-0">{{ $flag }}</span>{{ end }}
+          <a href="/datacenters/{{ .identifier }}/" class="sd-country-card">
+            <div style="display: flex; align-items: center; gap: 0.5rem;">
+              <span style="width: 0.5rem; height: 0.5rem; border-radius: 50%; background: {{ $dotColor }}; flex-shrink: 0;"></span>
+              <span class="sd-country-card-name">{{ .name }}</span>
+              {{ if $flag }}<span style="flex-shrink: 0;">{{ $flag }}</span>{{ end }}
             </div>
-            <div class="text-xs text-neutral-500 dark:text-neutral-400 mt-1.5 space-y-0.5">
-              <div>Datacenters: {{ .count }}</div>
-              <div>Countries: {{ .countryCount }}</div>
-              <div>Cities: {{ .cityCount }}</div>
+            <div class="sd-country-card-meta">
+              <span>{{ .count }} DCs</span>
+              <span>{{ .countryCount }} countries</span>
+              <span>{{ .cityCount }} cities</span>
             </div>
           </a>
           {{ end }}
         </div>
         {{ end }}
       {{ end }}
-    </div>
-    {{ end }}
+      {{ end }}
 
-    {{/* Footer navigation */}}
-    <div class="divider"></div>
-    <div class="flex flex-wrap gap-4">
-      <a href="/countries/" class="btn btn-outline btn-sm">← All Countries</a>
-      <a href="/datacenters/" class="btn btn-outline btn-sm">Browse Datacenters</a>
+      {{/* Footer navigation */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/countries/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all countries</a>
+      </div>
+
     </div>
-  </article>
+  </section>
+
+</article>
 
   {{/* Floating TOC for mobile */}}
   {{ $tocSections := slice }}
+  {{ if gt (len ($bloc.inheritsFrom | default (slice))) 0 }}
+    {{ $tocSections = $tocSections | append (dict "id" "inherits" "title" "Inherits" "icon" "🔗") }}
+  {{ end }}
   {{ if gt (len $directMembers) 0 }}
     {{ $tocSections = $tocSections | append (dict "id" "map" "title" "Map" "icon" "🗺️") }}
   {{ end }}
   {{ if gt $lawCount 0 }}
-    {{ $tocSections = $tocSections | append (dict "id" "laws" "title" "Applicable Laws" "icon" "⚖️") }}
+    {{ $tocSections = $tocSections | append (dict "id" "laws" "title" "Laws" "icon" "⚖️") }}
   {{ end }}
   {{ if gt $memberCount 0 }}
-    {{ $tocSections = $tocSections | append (dict "id" "members" "title" "Member Countries" "icon" "🌍") }}
+    {{ $tocSections = $tocSections | append (dict "id" "members" "title" "Members" "icon" "🌍") }}
   {{ end }}
   {{ if gt $datacenterCount 0 }}
     {{ $tocSections = $tocSections | append (dict "id" "providers" "title" "Providers" "icon" "🖥️") }}
   {{ end }}
-  {{ $tocSections = $tocSections | append (dict "id" "sidebar" "title" "Details" "icon" "📋") }}
   {{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+  {{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/countries/list.html
+++ b/layouts/countries/list.html
@@ -1,73 +1,129 @@
 {{ define "main" }}
-<article class="max-w-full">
-  {{/* Section Header */}}
-  {{ partial "section-header.html" (dict
-      "title" .Title
-      "description" .Description
-      "icon" "globe"
-  ) }}
+{{/* Compute stats */}}
+{{ $countries := site.Data.countries.countries.itemListElement | default (slice) }}
+{{ $totalCountries := len $countries }}
 
-  {{/* Section Content - render markdown content which includes map shortcode */}}
-  <section class="max-w-full mt-6 prose dark:prose-invert prose-table:w-full prose-img:max-w-full [&>*]:max-w-none">
-    {{ .Content }}
-  </section>
+{{ $totalDc := 0 }}
+{{ range (site.Data.datacenters.datacenters | default (slice)) }}
+  {{ $totalDc = add $totalDc (len (.regions | default (slice))) }}
+{{ end }}
 
-  {{/* Country List */}}
-  <section class="mt-8">
-    {{/* Build country data with datacenter and law counts */}}
-    {{ $countries := site.Data.countries.countries.itemListElement | default (slice) }}
-    {{ $countryData := slice }}
+{{ $totalLaws := len (site.Data.laws.laws.itemListElement | default (slice)) }}
 
-    {{ range $countries }}
-      {{ $country := . }}
-      {{ $countryId := .identifier }}
+{{/* Build country data with datacenter and law counts */}}
+{{ $countryData := slice }}
+{{ range $countries }}
+  {{ $country := . }}
+  {{ $countryId := .identifier }}
 
-      {{/* Count datacenters for this country */}}
-      {{ $dcCount := 0 }}
-      {{ range (site.Data.datacenters.datacenters | default (slice)) }}
-        {{ range (.regions | default (slice)) }}
-          {{ if eq .countryId $countryId }}
-            {{ $dcCount = add $dcCount 1 }}
-          {{ end }}
-        {{ end }}
+  {{ $dcCount := 0 }}
+  {{ range (site.Data.datacenters.datacenters | default (slice)) }}
+    {{ range (.regions | default (slice)) }}
+      {{ if eq .countryId $countryId }}
+        {{ $dcCount = add $dcCount 1 }}
       {{ end }}
-
-      {{/* Count local laws for this country */}}
-      {{ $lawCount := 0 }}
-      {{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
-        {{ if in .legislationJurisdiction $countryId }}
-          {{ $lawCount = add $lawCount 1 }}
-        {{ end }}
-      {{ end }}
-
-      {{ $countryData = $countryData | append (dict
-        "identifier" $countryId
-        "name" $country.name
-        "flag" $country.flag
-        "slug" $country.slug
-        "dcCount" $dcCount
-        "lawCount" $lawCount
-      ) }}
     {{ end }}
+  {{ end }}
 
-    {{/* Sort by country name */}}
-    {{ $countryData = sort $countryData "name" "asc" }}
+  {{ $lawCount := 0 }}
+  {{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
+    {{ if in .legislationJurisdiction $countryId }}
+      {{ $lawCount = add $lawCount 1 }}
+    {{ end }}
+  {{ end }}
 
-    <div class="not-prose grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
-      {{ range $countryData }}
-      <a href="/countries/{{ .slug }}/" class="block p-2.5 rounded-lg border border-base-200 hover:border-primary/50 hover:bg-base-100 transition-all no-underline">
-        <div class="flex items-center gap-2">
-          <span class="text-lg flex-shrink-0">{{ .flag }}</span>
-          <span class="text-sm font-medium text-base-content truncate">{{ .name }}</span>
+  {{ $countryData = $countryData | append (dict
+    "identifier" $countryId
+    "name" $country.name
+    "flag" $country.flag
+    "slug" $country.slug
+    "dcCount" $dcCount
+    "lawCount" $lawCount
+  ) }}
+{{ end }}
+
+{{ $countryData = sort $countryData "name" "asc" }}
+
+<article class="sd-countries section-design">
+
+  {{/* ============================================================
+       HERO — Blue gradient
+       ============================================================ */}}
+  <section class="sd-events-hero">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Jurisdictions</span>
         </div>
-        <div class="text-xs text-neutral-500 dark:text-neutral-400 mt-1.5 space-y-0.5">
-          <div>Datacenters: {{ .dcCount }}</div>
-          <div>Local laws: {{ .lawCount }}</div>
-        </div>
-      </a>
-      {{ end }}
+        <h1 class="sd-headline sd-events-hero-title">Countries</h1>
+        <p class="sd-events-hero-description">
+          {{ .Description | default "Countries and regional blocs with datacenter infrastructure and data sovereignty characteristics." }}
+        </p>
+      </div>
     </div>
   </section>
+
+  {{/* ============================================================
+       STATS — 3 cards overlapping hero
+       ============================================================ */}}
+  <section class="sd-events-stats sd-countries-stats">
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Countries</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $totalCountries }}</span>
+        <span class="sd-events-stat-desc">Tracked jurisdictions</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Datacenter Regions</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $totalDc }}</span>
+        <span class="sd-events-stat-desc">Across all providers</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Laws</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $totalLaws }}</span>
+        <span class="sd-events-stat-desc">Data sovereignty laws</span>
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       CONTENT — Map shortcode and bloc cards from _index.md
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+      {{ .Content }}
+    </div>
+  </section>
+
+  {{/* ============================================================
+       COUNTRY GRID
+       ============================================================ */}}
+  <section class="sd-blog-feed" style="padding-top: 0;">
+    <div class="sd-dc-content">
+      <h2 id="browse-by-country" style="scroll-margin-top: 5rem;">Browse by Country</h2>
+      <div class="sd-country-grid">
+        {{ range $countryData }}
+        <a href="/countries/{{ .slug }}/" class="sd-country-card">
+          <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <span style="font-size: 1.25rem; flex-shrink: 0;">{{ .flag }}</span>
+            <span class="sd-country-card-name">{{ .name }}</span>
+          </div>
+          <div class="sd-country-card-meta">
+            <span>{{ .dcCount }} datacenters</span>
+            <span>{{ .lawCount }} laws</span>
+          </div>
+        </a>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+
 </article>
 
 {{/* Floating TOC for mobile */}}
@@ -77,4 +133,5 @@
     (dict "id" "browse-by-country" "title" "Countries" "icon" "🏳️")
 }}
 {{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/countries/single.html
+++ b/layouts/countries/single.html
@@ -36,7 +36,7 @@
   {{ $regionsById = merge $regionsById (dict .identifier .) }}
 {{ end }}
 
-{{/* Compute datacenter provider stats for sidebar */}}
+{{/* Compute datacenter provider stats */}}
 {{ $providers := site.Data.datacenters.datacenters | default (slice) }}
 {{ $providerItems := slice }}
 {{ $totalRegions := 0 }}
@@ -58,44 +58,203 @@
 {{ $providerItems = sort $providerItems "name" "asc" }}
 {{ $providerItems = sort $providerItems "count" "desc" }}
 
-{{/* Build pageData for content partial */}}
-{{ $pageData := dict
-    "countryId" $countryId
-    "country" $country
-    "countryName" $countryName
-    "regionsById" $regionsById
+{{/* Compute law count */}}
+{{ $lawCount := 0 }}
+{{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
+  {{ if in .legislationJurisdiction $countryId }}
+    {{ $lawCount = add $lawCount 1 }}
+  {{ end }}
+{{ end }}
+
+{{/* Resolve risk level */}}
+{{ $riskLevel := "" }}
+{{ $riskEmoji := "" }}
+{{ with $country }}
+  {{ $riskLevel = .riskLevel | default "" }}
+  {{ if eq $riskLevel "low" }}{{ $riskEmoji = "✅" }}
+  {{ else if eq $riskLevel "medium" }}{{ $riskEmoji = "⚠️" }}
+  {{ else if eq $riskLevel "high" }}{{ $riskEmoji = "🔶" }}
+  {{ else if eq $riskLevel "critical" }}{{ $riskEmoji = "🚨" }}
+  {{ else if eq $riskLevel "restricted" }}{{ $riskEmoji = "⛔" }}
+  {{ end }}
+{{ end }}
+
+{{/* Resolve bloc memberships */}}
+{{ $blocs := slice }}
+{{ $allCountries := site.Data.countries.countries.itemListElement | default (slice) }}
+{{ range $allCountries }}
+  {{ if .memberCountryIds }}
+    {{ if in .memberCountryIds $countryId }}
+      {{ $blocs = $blocs | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<article class="sd-countries section-design">
+
+  {{/* ============================================================
+       HERO — Compact detail hero with breadcrumbs
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        {{/* Breadcrumbs */}}
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/countries/" style="color: inherit; text-decoration: none; opacity: 0.7;">Countries</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ $countryName }}</span>
+          </span>
+        </nav>
+
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Jurisdiction</span>
+        </div>
+
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">
+          {{ if $countryFlag }}<span style="margin-right: 0.5rem;">{{ $countryFlag }}</span>{{ end }}{{ $countryName }}
+        </h1>
+
+        {{ with .Description }}
+        <p class="sd-events-hero-description">{{ . }}</p>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       METADATA GRID — Inline cards replacing sidebar
+       ============================================================ */}}
+  <section class="sd-events-stats sd-country-detail-meta">
+    {{/* Country Details card */}}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Country Details</span>
+      <dl style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.8;">
+        {{ if $riskLevel }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Risk Level</dt>
+          <dd style="font-weight: 500;">{{ $riskEmoji }} {{ $riskLevel | title }}</dd>
+        </div>
+        {{ end }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Providers</dt>
+          <dd style="font-weight: 500;">{{ len $providerItems }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">DC Regions</dt>
+          <dd style="font-weight: 500;">{{ $totalRegions }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Laws</dt>
+          <dd style="font-weight: 500;">{{ $lawCount }}</dd>
+        </div>
+      </dl>
+    </div>
+
+    {{/* Memberships card */}}
+    {{ if gt (len $blocs) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Bloc Memberships</span>
+      <div style="margin-top: 0.5rem;" class="sd-filter-pills">
+        {{ range $blocs }}
+        <a href="/countries/{{ .slug }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+          {{ with .flag }}{{ . }} {{ end }}{{ .name }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+
+    {{/* Top Providers card */}}
+    {{ if gt (len $providerItems) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Top Providers</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range first 5 $providerItems }}
+        <li style="display: flex; justify-content: space-between; align-items: center;">
+          <span>{{ .name }}</span>
+          <span style="opacity: 0.6; font-size: 0.75rem;">{{ .count }} regions</span>
+        </li>
+        {{ end }}
+        {{ if gt (len $providerItems) 5 }}
+        <li style="opacity: 0.5; font-size: 0.75rem;">+ {{ sub (len $providerItems) 5 }} more</li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+  </section>
+
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* Summary */}}
+      {{ with .Params.summary }}
+      <p style="font-size: 1.125rem; color: var(--sd-on-surface-variant); line-height: 1.7; margin-bottom: 1.5rem;">{{ . }}</p>
+      {{ end }}
+
+      {{/* Body */}}
+      {{ with .Params.body }}
+      <p>{{ . }}</p>
+      {{ end }}
+
+      {{ if $countryId }}
+        {{/* Map */}}
+        <h2 id="map">Datacenter Map</h2>
+        <div class="not-prose" style="margin-top: 1rem;">
+          {{ $mapShortcode := printf "{{< datacenter-map countries=\"%s\" showFilters=\"false\" >}}" $countryId }}
+          {{ $mapShortcode | .RenderString }}
+        </div>
+
+        {{/* Laws */}}
+        <h2 id="laws">Laws in this jurisdiction</h2>
+        {{ partial "jurisdiction-laws-inline.html" (dict "jurisdictionId" $countryId "country" $country) }}
+
+        {{/* Providers */}}
+        <h2 id="providers">Providers in {{ $countryName }}</h2>
+        {{ partial "datacenter-country-providers-inline.html" (dict "countryId" $countryId "regionsById" $regionsById) }}
+
+        {{/* Page content from markdown */}}
+        {{ if .Content }}
+        <hr style="border-color: var(--sd-outline-variant); margin: 2rem 0;">
+        {{ .Content }}
+        {{ end }}
+
+        {{/* Related content */}}
+        {{ with .GetTerms "tags" }}
+        <div style="margin-top: 2rem;">
+          <h3>Tags</h3>
+          <div class="sd-filter-pills">
+            {{ range . }}
+            <a href="{{ .RelPermalink }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ .LinkTitle }}</a>
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
+      {{ end }}
+
+      {{/* Back link */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/countries/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all countries</a>
+      </div>
+
+    </div>
+  </section>
+
+</article>
+
+{{/* Floating TOC */}}
+{{ $tocSections := slice
+    (dict "id" "map" "title" "Map" "icon" "🗺️")
+    (dict "id" "laws" "title" "Laws" "icon" "⚖️")
+    (dict "id" "providers" "title" "Providers" "icon" "🖥️")
 }}
-
-{{ partial "common-single-page.html" (dict
-    "page" .
-    "flag" $countryFlag
-    "section" "Countries"
-    "sectionUrl" "/countries/"
-    "headerDescription" .Description
-    "showAbstract" false
-    "showSummary" false
-    "showFeaturedImage" false
-    "showQuote" false
-    "showToc" false
-    "showFloatingToc" false
-    "contentPartial" "content/countries-content.html"
-    "pageData" $pageData
-    "sidebarCards" (slice
-        (dict "partial" "sidebar/datacenter-country-details-card.html"
-              "params" (dict "country" $country "providerCount" (len $providerItems) "regionCount" $totalRegions))
-        (dict "partial" "sidebar/countries-datacenters-link-card.html"
-              "params" (dict "slug" $slug "countryName" $countryName "totalRegions" $totalRegions))
-        (dict "partial" "sidebar/jurisdiction-risk-card.html"
-              "params" (dict "countryId" $countryId))
-        (dict "partial" "sidebar/jurisdiction-memberships-card.html"
-              "params" (dict "countryId" $countryId))
-        (dict "partial" "sidebar/jurisdiction-laws-card.html"
-              "params" (dict "countryId" $countryId))
-        (dict "partial" "datacenter-country-providers-sidebar.html"
-              "params" (dict "providerItems" $providerItems "countryName" $countryName "countryFlag" $countryFlag))
-        (dict "partial" "related-content-sidebar.html"
-              "params" (dict "page" . "countryId" $countryId))
-    )
-) }}
-
+{{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/networks/list.html
+++ b/layouts/networks/list.html
@@ -1,62 +1,90 @@
 {{ define "main" }}
-<article class="max-w-full">
-  {{/* Section Header */}}
-  {{ partial "section-header.html" (dict
-      "title" .Title
-      "description" .Description
-      "icon" "globe"
-  ) }}
+{{/* Compute stats from network data */}}
+{{ $networks := index site.Data "networks" "networks" }}
+{{ $total := len $networks }}
+{{ $subsea := 0 }}
+{{ $terrestrial := 0 }}
+{{ $active := 0 }}
+{{ range $networks }}
+  {{ if eq .medium "subsea" }}{{ $subsea = add $subsea 1 }}{{ end }}
+  {{ if eq .medium "terrestrial" }}{{ $terrestrial = add $terrestrial 1 }}{{ end }}
+  {{ if eq .status "active" }}{{ $active = add $active 1 }}{{ end }}
+{{ end }}
 
-  {{/* Section Stats */}}
-  {{ $networks := index site.Data "networks" "networks" }}
-  {{ $total := len $networks }}
-  {{ $subsea := 0 }}
-  {{ $terrestrial := 0 }}
-  {{ $active := 0 }}
-  {{ range $networks }}
-    {{ if eq .medium "subsea" }}{{ $subsea = add $subsea 1 }}{{ end }}
-    {{ if eq .medium "terrestrial" }}{{ $terrestrial = add $terrestrial 1 }}{{ end }}
-    {{ if eq .status "active" }}{{ $active = add $active 1 }}{{ end }}
-  {{ end }}
+<article class="sd-networks section-design">
 
-  <div class="stats stats-vertical lg:stats-horizontal shadow-lg w-full bg-base-100 mb-8">
-    <div class="stat">
-      <div class="stat-figure text-primary">
-        {{ partial "data-icon.html" (dict "name" "globe" "color" "primary" "size" "8") }}
+  {{/* ============================================================
+       HERO — Blue gradient
+       ============================================================ */}}
+  <section class="sd-events-hero">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Infrastructure</span>
+        </div>
+        <h1 class="sd-headline sd-events-hero-title">Networks</h1>
+        <p class="sd-events-hero-description">
+          {{ .Description | default "Submarine cables, terrestrial fibre, and network infrastructure connecting Norway to the world." }}
+        </p>
       </div>
-      <div class="stat-title">Total Connections</div>
-      <div class="stat-value text-primary">{{ $total }}</div>
-      <div class="stat-desc">Mapped networks</div>
     </div>
-    <div class="stat">
-      <div class="stat-figure text-info">
-        {{ partial "data-icon.html" (dict "name" "bolt" "color" "info" "size" "8") }}
-      </div>
-      <div class="stat-title">Submarine Cables</div>
-      <div class="stat-value text-info">{{ $subsea }}</div>
-      <div class="stat-desc">Undersea routes</div>
-    </div>
-    <div class="stat">
-      <div class="stat-figure text-secondary">
-        {{ partial "data-icon.html" (dict "name" "location" "color" "secondary" "size" "8") }}
-      </div>
-      <div class="stat-title">Land Connections</div>
-      <div class="stat-value text-secondary">{{ $terrestrial }}</div>
-      <div class="stat-desc">Terrestrial routes</div>
-    </div>
-    <div class="stat">
-      <div class="stat-figure text-success">
-        {{ partial "data-icon.html" (dict "name" "check-circle" "color" "success" "size" "8") }}
-      </div>
-      <div class="stat-title">Active</div>
-      <div class="stat-value text-success">{{ $active }}</div>
-      <div class="stat-desc">Operational now</div>
-    </div>
-  </div>
-
-  {{/* Section Content - render markdown content which includes map and data tables */}}
-  <section class="max-w-full mt-6 prose dark:prose-invert prose-table:w-full prose-img:max-w-full [&>*]:max-w-none">
-    {{ .Content }}
   </section>
+
+  {{/* ============================================================
+       STATS — 4 cards overlapping hero
+       ============================================================ */}}
+  <section class="sd-events-stats">
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Total Connections</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $total }}</span>
+        <span class="sd-events-stat-desc">Mapped networks</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Submarine Cables</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $subsea }}</span>
+        <span class="sd-events-stat-desc">Undersea routes</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Land Connections</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $terrestrial }}</span>
+        <span class="sd-events-stat-desc">Terrestrial routes</span>
+      </div>
+    </div>
+    <div class="sd-events-stat-card">
+      <span class="sd-events-stat-label">Active</span>
+      <div class="sd-events-stat-row">
+        <span class="sd-headline sd-events-stat-value">{{ $active }}</span>
+        <span class="sd-events-stat-desc">Operational now</span>
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       CONTENT — Shortcodes rendered from _index.md
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+      {{ .Content }}
+    </div>
+  </section>
+
 </article>
+
+{{/* Floating TOC for mobile */}}
+{{ $tocSections := slice
+    (dict "id" "network-filter-panel" "title" "Map" "icon" "🗺️")
+    (dict "id" "subsea-international" "title" "Subsea" "icon" "⚡")
+    (dict "id" "terrestrial-international" "title" "Terrestrial" "icon" "📍")
+    (dict "id" "domestic-norway" "title" "Domestic" "icon" "🇳🇴")
+    (dict "id" "arctic-connectivity" "title" "Arctic" "icon" "🌐")
+}}
+{{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/networks/single.html
+++ b/layouts/networks/single.html
@@ -59,60 +59,308 @@
 
 {{/* Build endpoints display */}}
 {{ $endpointNames := slice }}
+{{ $endpointDetails := slice }}
 {{ if $connection }}
   {{ range $connection.endpointPlaceIds }}
     {{ $place := index $placeById . }}
     {{ $flag := "" }}
+    {{ $name := . }}
     {{ if $place }}
+      {{ $name = $place.name | default . }}
       {{ $countryId := "" }}
       {{ with $place.address }}{{ $countryId = .addressCountry }}{{ end }}
       {{ if $countryId }}
         {{ $region := index $countriesById $countryId }}
         {{ if $region }}{{ $flag = $region.flag }}{{ end }}
       {{ end }}
-      {{ $endpointNames = $endpointNames | append (printf "%s %s" $flag ($place.name | default .)) }}
+      {{ $endpointNames = $endpointNames | append (printf "%s %s" $flag $name) }}
+      {{ $endpointDetails = $endpointDetails | append (dict "name" $name "flag" $flag "id" .) }}
     {{ else }}
       {{ $endpointNames = $endpointNames | append . }}
+      {{ $endpointDetails = $endpointDetails | append (dict "name" . "flag" "" "id" .) }}
     {{ end }}
   {{ end }}
 {{ end }}
 
-{{/* Build pageData for content partial */}}
-{{ $pageData := dict
-    "identifier" $identifier
-    "connection" $connection
-    "connections" $connections
-    "places" $places
-    "actors" $actors
-    "endpointNames" $endpointNames
-}}
+{{/* Status badge color */}}
+{{ $statusColor := "background-color: #16a34a; color: #fff;" }}
+{{ $statusLabel := "Active" }}
+{{ if $connection }}
+  {{ $statusLabel = $connection.status | default "unknown" | title }}
+  {{ if eq $connection.status "planned" }}
+    {{ $statusColor = "background-color: #d97706; color: #fff;" }}
+  {{ end }}
+  {{ if eq $connection.status "decommissioned" }}
+    {{ $statusColor = "background-color: #6b7280; color: #fff;" }}
+  {{ end }}
+{{ end }}
 
-{{ partial "common-single-page.html" (dict
-    "page" .
-    "icon" "network"
-    "section" "Networks"
-    "sectionUrl" "/networks/"
-    "headerDescription" .Description
-    "externalUrl" $externalUrl
-    "externalLabel" "View on SubmarineCableMap"
-    "showAbstract" false
-    "showSummary" false
-    "showFeaturedImage" false
-    "showQuote" false
-    "showToc" false
-    "contentPartial" "content/networks-content.html"
-    "pageData" $pageData
-    "sidebarCards" (slice
-        "sidebar/networks-details-card.html"
-        "sidebar/common-topics-card.html"
-        "sidebar/common-tags-card.html"
-        (dict "partial" "sidebar/networks-endpoints-card.html"
-              "params" (dict "connection" $connection "placeById" $placeById "countriesById" $countriesById))
-        (dict "partial" "sidebar/networks-owners-card.html"
-              "params" (dict "connection" $connection "actorById" $actorById "countriesById" $countriesById))
-        (dict "partial" "sidebar/networks-links-card.html"
-              "params" (dict "connection" $connection))
-    )
-) }}
+{{/* Medium color */}}
+{{ $mediumDot := "" }}
+{{ $mediumLabel := "" }}
+{{ if $connection }}
+  {{ $mediumLabel = $connection.medium | default "" | title }}
+  {{ if eq $connection.medium "subsea" }}
+    {{ $mediumDot = "#06b6d4" }}
+  {{ end }}
+  {{ if eq $connection.medium "terrestrial" }}
+    {{ $mediumDot = "#a855f7" }}
+  {{ end }}
+{{ end }}
 
+{{/* Scope emoji */}}
+{{ $scopeEmoji := "" }}
+{{ if $connection }}
+  {{ if eq $connection.scope "international" }}{{ $scopeEmoji = "🌍" }}{{ end }}
+  {{ if eq $connection.scope "domestic" }}{{ $scopeEmoji = "🏠" }}{{ end }}
+{{ end }}
+
+{{/* Owner details */}}
+{{ $ownerDetails := slice }}
+{{ if $connection }}
+  {{ with $connection.ownerActorIds }}
+    {{ range . }}
+      {{ $actor := index $actorById . }}
+      {{ $flag := "" }}
+      {{ $name := . }}
+      {{ if $actor }}
+        {{ $name = $actor.name | default . }}
+        {{ $countryId := $actor.countryId | default "" }}
+        {{ if $countryId }}
+          {{ $region := index $countriesById $countryId }}
+          {{ if $region }}{{ $flag = $region.flag }}{{ end }}
+        {{ end }}
+      {{ end }}
+      {{ $ownerDetails = $ownerDetails | append (dict "name" $name "flag" $flag "id" .) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<article class="sd-networks section-design">
+
+  {{/* ============================================================
+       HERO — Compact detail hero with breadcrumbs
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        {{/* Breadcrumbs */}}
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/networks/" style="color: inherit; text-decoration: none; opacity: 0.7;">Networks</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ $displayTitle }}</span>
+          </span>
+        </nav>
+
+        {{/* Status badge */}}
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>{{ $statusLabel }}</span>
+        </div>
+
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">{{ $displayTitle }}</h1>
+
+        {{/* Route summary line */}}
+        {{ if gt (len $endpointNames) 0 }}
+        <p class="sd-events-hero-description" style="font-size: 1.125rem;">
+          {{ delimit $endpointNames " → " }}
+        </p>
+        {{ end }}
+
+        {{/* Description from front matter */}}
+        {{ with .Description }}
+        <p class="sd-events-hero-description" style="margin-top: 0.5rem;">{{ . }}</p>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       METADATA GRID — Inline cards replacing sidebar
+       ============================================================ */}}
+  {{ if $connection }}
+  <section class="sd-events-stats sd-network-detail-meta">
+    {{/* Connection Details card */}}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Connection Details</span>
+      <dl style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.8;">
+        {{ with $connection.scope }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Scope</dt>
+          <dd style="font-weight: 500;">{{ $scopeEmoji }} {{ . | title }}</dd>
+        </div>
+        {{ end }}
+        {{ with $connection.medium }}
+        <div style="display: flex; justify-content: space-between; align-items: center;">
+          <dt style="opacity: 0.6;">Medium</dt>
+          <dd style="font-weight: 500; display: flex; align-items: center; gap: 0.375rem;">
+            {{ if $mediumDot }}<span style="width: 0.625rem; height: 0.625rem; border-radius: 50%; background: {{ $mediumDot }};"></span>{{ end }}
+            {{ . | title }}
+          </dd>
+        </div>
+        {{ end }}
+        {{ with $connection.type }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Type</dt>
+          <dd style="font-weight: 500;">{{ . | title }}</dd>
+        </div>
+        {{ end }}
+        {{ with $connection.operationalDate }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Operational</dt>
+          <dd style="font-weight: 500;">{{ . }}</dd>
+        </div>
+        {{ end }}
+        {{ with $connection.lengthKm }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Length</dt>
+          <dd style="font-weight: 500;">{{ . | lang.FormatNumber 0 }} km</dd>
+        </div>
+        {{ end }}
+      </dl>
+    </div>
+
+    {{/* Endpoints card */}}
+    {{ if gt (len $endpointDetails) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Endpoints</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range $endpointDetails }}
+        <li style="display: flex; align-items: center; gap: 0.5rem;">
+          {{ if .flag }}<span>{{ .flag }}</span>{{ end }}
+          <span>{{ .name }}</span>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+
+    {{/* Owners card */}}
+    {{ if gt (len $ownerDetails) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Owners</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range $ownerDetails }}
+        <li style="display: flex; align-items: center; gap: 0.5rem;">
+          {{ if .flag }}<span>{{ .flag }}</span>{{ end }}
+          <span>{{ .name }}</span>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+  </section>
+  {{ end }}
+
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* Abstract */}}
+      {{ with $connection.abstract }}
+      <p style="font-size: 1.125rem; color: var(--sd-on-surface-variant); line-height: 1.7; margin-bottom: 1.5rem;">{{ . }}</p>
+      {{ end }}
+
+      {{/* Summary */}}
+      {{ with $connection.summary }}
+      <p>{{ . }}</p>
+      {{ end }}
+
+      {{/* Route Section with Map */}}
+      {{ if $connection }}
+      <h2>Route</h2>
+      <p><strong>Endpoints:</strong> {{ delimit $endpointNames " → " }}</p>
+
+      {{ partial "network-connection-map-inline.html" (dict "identifier" $identifier "connection" $connection "places" $places) }}
+
+      {{ if $connection.route }}
+      <p style="font-size: 0.875rem; color: var(--sd-on-surface-variant); font-style: italic;">Schematic polyline is available for map rendering.</p>
+      {{ else }}
+      <p style="font-size: 0.875rem; color: var(--sd-on-surface-variant); font-style: italic;">Route is auto-generated for visualization from endpoints (schematic).</p>
+      {{ end }}
+      {{ end }}
+
+      {{/* Owners & Operators Section */}}
+      {{ if $connection }}
+      <h2>Owners &amp; Operators</h2>
+      {{ partial "network-actors-inline.html" (dict "identifier" $identifier "connection" $connection "connections" $connections "actors" $actors) }}
+      {{ end }}
+
+      {{/* Page content from markdown */}}
+      {{ .Content }}
+
+      {{/* Topics as filter pills */}}
+      {{ with .Params.topics }}
+      <div style="margin-top: 2rem;">
+        <h3>Topics</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="/topics/{{ . | urlize }}/" class="sd-filter-pill" style="text-decoration: none;">{{ . }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* Tags as filter pills */}}
+      {{ with .Params.tags }}
+      <div style="margin-top: 1rem;">
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="/tags/{{ . | urlize }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ . }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* External links */}}
+      {{ if $connection }}
+      {{ with $connection.sources }}
+      <div style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <h3>External Links</h3>
+        <ul style="list-style: none; padding: 0;">
+          {{ range . }}
+          <li style="margin-bottom: 0.5rem;">
+            <a href="{{ .url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               style="display: inline-flex; align-items: center; gap: 0.375rem; font-size: 0.875rem; text-decoration: none; color: var(--sd-primary);">
+              ↗ {{ .title }}
+            </a>
+          </li>
+          {{ end }}
+        </ul>
+      </div>
+      {{ end }}
+      {{ end }}
+
+      {{/* External URL button */}}
+      {{ if $externalUrl }}
+      <div style="margin-top: 1.5rem;">
+        <a href="{{ $externalUrl }}"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="sd-filter-pill sd-filter-pill-active"
+           style="text-decoration: none; display: inline-flex; align-items: center; gap: 0.375rem;">
+          ↗ View on SubmarineCableMap
+        </a>
+      </div>
+      {{ end }}
+
+      {{/* Back link */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/networks/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all networks</a>
+      </div>
+
+    </div>
+  </section>
+
+</article>
+
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/shortcodes/network-data.html
+++ b/layouts/shortcodes/network-data.html
@@ -35,7 +35,7 @@
 {{ $arcticCables := where $connections "identifier" "in" (slice "svalbard-undersea" "arctic-way" "longyearbyen-ny-alesund") }}
 
 <div class="space-y-10">
-  <section>
+  <section id="subsea-international">
     <h3 class="text-xl font-semibold flex items-center gap-2">
       {{ partial "data-icon.html" (dict "name" "bolt" "color" "info" "size" "6") }}
       Subsea (Outside Norway)
@@ -102,7 +102,7 @@
     <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">Count: {{ len $internationalSubsea }}</p>
   </section>
 
-  <section>
+  <section id="terrestrial-international">
     <h3 class="text-xl font-semibold flex items-center gap-2">
       {{ partial "data-icon.html" (dict "name" "location" "color" "secondary" "size" "6") }}
       Terrestrial (Outside Norway)
@@ -160,7 +160,7 @@
     <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">Count: {{ len $internationalTerrestrial }}</p>
   </section>
 
-  <section>
+  <section id="domestic-norway">
     <h3 class="text-xl font-semibold flex items-center gap-2">
       {{ partial "data-icon.html" (dict "name" "flag" "color" "primary" "size" "6") }}
       Domestic (Inside Norway)
@@ -214,7 +214,7 @@
     <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">Count: {{ len $domesticCables }}</p>
   </section>
 
-  <section>
+  <section id="arctic-connectivity">
     <h3 class="text-xl font-semibold flex items-center gap-2">
       {{ partial "data-icon.html" (dict "name" "globe" "color" "accent" "size" "6") }}
       Arctic Connectivity

--- a/layouts/shortcodes/network-data.html
+++ b/layouts/shortcodes/network-data.html
@@ -22,9 +22,6 @@
   {{ with $pl.identifier }}{{ $s.SetInMap "placeById" . $pl }}{{ end }}
 {{ end }}
 
-{{/* Status badge helper - returns HTML with icon */}}
-{{/* We'll render status inline with partials */}}
-
 {{ $actorById := $s.Get "actorById" }}
 {{ $placeById := $s.Get "placeById" }}
 
@@ -34,21 +31,21 @@
 
 {{ $arcticCables := where $connections "identifier" "in" (slice "svalbard-undersea" "arctic-way" "longyearbyen-ny-alesund") }}
 
-<div class="space-y-10">
+<div class="sd-network-tables">
   <section id="subsea-international">
-    <h3 class="text-xl font-semibold flex items-center gap-2">
+    <h3>
       {{ partial "data-icon.html" (dict "name" "bolt" "color" "info" "size" "6") }}
       Subsea (Outside Norway)
     </h3>
-    <p class="text-sm text-neutral-600 dark:text-neutral-300">Cables running along the ocean floor connecting Norway to other countries. These cables are vulnerable to damage from fishing trawlers, anchors, and—in recent years—<a href="/tags/submarine-cables/" class="underline hover:text-primary-500">suspected sabotage</a>.</p>
-    <div class="mt-3 overflow-x-auto">
-      <table class="min-w-full text-sm">
-        <thead class="text-left">
-          <tr class="border-b border-neutral-200 dark:border-neutral-700">
-            <th class="py-2 pr-4">System</th>
-            <th class="py-2 pr-4">Status</th>
-            <th class="py-2 pr-4">Route</th>
-            <th class="py-2">Owners</th>
+    <p class="sd-network-section-desc">Cables running along the ocean floor connecting Norway to other countries. These cables are vulnerable to damage from fishing trawlers, anchors, and—in recent years—<a href="/tags/submarine-cables/">suspected sabotage</a>.</p>
+    <div class="sd-table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>System</th>
+            <th>Status</th>
+            <th>Route</th>
+            <th>Owners</th>
           </tr>
         </thead>
         <tbody>
@@ -74,49 +71,49 @@
                 {{ $routeNames = $routeNames | append . }}
               {{ end }}
             {{ end }}
-            <tr class="border-b border-neutral-100 dark:border-neutral-800">
-              <td class="py-2 pr-4 font-medium">
+            <tr>
+              <td>
                 {{ if $page }}
-                  <a class="hover:underline" href="{{ $page.RelPermalink }}">{{ .name }}</a>
+                  <a href="{{ $page.RelPermalink }}">{{ .name }}</a>
                 {{ else }}
                   {{ .name }}
                 {{ end }}
               </td>
-              <td class="py-2 pr-4">
+              <td>
                 {{ $status := .status | default "active" }}
                 {{ if eq $status "active" }}
-                <span class="badge badge-success badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
+                <span class="sd-status-badge sd-status-active">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
                 {{ else if eq $status "planned" }}
-                <span class="badge badge-warning badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
+                <span class="sd-status-badge sd-status-planned">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
                 {{ else }}
-                <span class="badge badge-ghost badge-sm">{{ $status }}</span>
+                <span class="sd-status-badge">{{ $status }}</span>
                 {{ end }}
               </td>
-              <td class="py-2 pr-4">{{ delimit $routeNames " ↔ " }}</td>
-              <td class="py-2">{{ if gt (len $owners) 0 }}{{ delimit $owners ", " }}{{ else }}—{{ end }}</td>
+              <td>{{ delimit $routeNames " ↔ " }}</td>
+              <td>{{ if gt (len $owners) 0 }}{{ delimit $owners ", " }}{{ else }}—{{ end }}</td>
             </tr>
           {{ end }}
         </tbody>
       </table>
     </div>
-    <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">Count: {{ len $internationalSubsea }}</p>
+    <p class="sd-network-count">Count: {{ len $internationalSubsea }}</p>
   </section>
 
   <section id="terrestrial-international">
-    <h3 class="text-xl font-semibold flex items-center gap-2">
+    <h3>
       {{ partial "data-icon.html" (dict "name" "location" "color" "secondary" "size" "6") }}
       Terrestrial (Outside Norway)
     </h3>
-    <p class="text-sm text-neutral-600 dark:text-neutral-300">Land-based fibre routes crossing Norway's borders to Sweden, Finland, and beyond.</p>
+    <p class="sd-network-section-desc">Land-based fibre routes crossing Norway's borders to Sweden, Finland, and beyond.</p>
 
-    <div class="mt-3 overflow-x-auto">
-      <table class="min-w-full text-sm">
-        <thead class="text-left">
-          <tr class="border-b border-neutral-200 dark:border-neutral-700">
-            <th class="py-2 pr-4">Connection</th>
-            <th class="py-2 pr-4">Status</th>
-            <th class="py-2 pr-4">Route</th>
-            <th class="py-2">Notes</th>
+    <div class="sd-table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Connection</th>
+            <th>Status</th>
+            <th>Route</th>
+            <th>Notes</th>
           </tr>
         </thead>
         <tbody>
@@ -132,49 +129,49 @@
                 {{ $routeNames = $routeNames | append . }}
               {{ end }}
             {{ end }}
-            <tr class="border-b border-neutral-100 dark:border-neutral-800">
-              <td class="py-2 pr-4 font-medium">
+            <tr>
+              <td>
                 {{ if $page }}
-                  <a class="hover:underline" href="{{ $page.RelPermalink }}">{{ .name }}</a>
+                  <a href="{{ $page.RelPermalink }}">{{ .name }}</a>
                 {{ else }}
                   {{ .name }}
                 {{ end }}
               </td>
-              <td class="py-2 pr-4">
+              <td>
                 {{ $status := .status | default "active" }}
                 {{ if eq $status "active" }}
-                <span class="badge badge-success badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
+                <span class="sd-status-badge sd-status-active">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
                 {{ else if eq $status "planned" }}
-                <span class="badge badge-warning badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
+                <span class="sd-status-badge sd-status-planned">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
                 {{ else }}
-                <span class="badge badge-ghost badge-sm">{{ $status }}</span>
+                <span class="sd-status-badge">{{ $status }}</span>
                 {{ end }}
               </td>
-              <td class="py-2 pr-4">{{ if gt (len $routeNames) 0 }}{{ delimit $routeNames " ↔ " }}{{ else }}—{{ end }}</td>
-              <td class="py-2">{{ .description | default "—" }}</td>
+              <td>{{ if gt (len $routeNames) 0 }}{{ delimit $routeNames " ↔ " }}{{ else }}—{{ end }}</td>
+              <td>{{ .description | default "—" }}</td>
             </tr>
           {{ end }}
         </tbody>
       </table>
     </div>
-    <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">Count: {{ len $internationalTerrestrial }}</p>
+    <p class="sd-network-count">Count: {{ len $internationalTerrestrial }}</p>
   </section>
 
   <section id="domestic-norway">
-    <h3 class="text-xl font-semibold flex items-center gap-2">
+    <h3>
       {{ partial "data-icon.html" (dict "name" "flag" "color" "primary" "size" "6") }}
       Domestic (Inside Norway)
     </h3>
-    <p class="text-sm text-neutral-600 dark:text-neutral-300">Cables and routes connecting regions within Norway—both undersea (coastal) and land-based.</p>
+    <p class="sd-network-section-desc">Cables and routes connecting regions within Norway—both undersea (coastal) and land-based.</p>
 
-    <div class="mt-3 overflow-x-auto">
-      <table class="min-w-full text-sm">
-        <thead class="text-left">
-          <tr class="border-b border-neutral-200 dark:border-neutral-700">
-            <th class="py-2 pr-4">System</th>
-            <th class="py-2 pr-4">Status</th>
-            <th class="py-2 pr-4">Medium</th>
-            <th class="py-2">Operators</th>
+    <div class="sd-table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>System</th>
+            <th>Status</th>
+            <th>Medium</th>
+            <th>Operators</th>
           </tr>
         </thead>
         <tbody>
@@ -186,72 +183,72 @@
               {{ $a := index $actorById . }}
               {{ $opNames = $opNames | append (cond $a ($a.name | default .) .) }}
             {{ end }}
-            <tr class="border-b border-neutral-100 dark:border-neutral-800">
-              <td class="py-2 pr-4 font-medium">
+            <tr>
+              <td>
                 {{ if $page }}
-                  <a class="hover:underline" href="{{ $page.RelPermalink }}">{{ .name }}</a>
+                  <a href="{{ $page.RelPermalink }}">{{ .name }}</a>
                 {{ else }}
                   {{ .name }}
                 {{ end }}
               </td>
-              <td class="py-2 pr-4">
+              <td>
                 {{ $status := .status | default "active" }}
                 {{ if eq $status "active" }}
-                <span class="badge badge-success badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
+                <span class="sd-status-badge sd-status-active">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
                 {{ else if eq $status "planned" }}
-                <span class="badge badge-warning badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
+                <span class="sd-status-badge sd-status-planned">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
                 {{ else }}
-                <span class="badge badge-ghost badge-sm">{{ $status }}</span>
+                <span class="sd-status-badge">{{ $status }}</span>
                 {{ end }}
               </td>
-              <td class="py-2 pr-4">{{ .medium | default "—" }}</td>
-              <td class="py-2">{{ if gt (len $opNames) 0 }}{{ delimit $opNames ", " }}{{ else }}—{{ end }}</td>
+              <td>{{ .medium | default "—" }}</td>
+              <td>{{ if gt (len $opNames) 0 }}{{ delimit $opNames ", " }}{{ else }}—{{ end }}</td>
             </tr>
           {{ end }}
         </tbody>
       </table>
     </div>
-    <p class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">Count: {{ len $domesticCables }}</p>
+    <p class="sd-network-count">Count: {{ len $domesticCables }}</p>
   </section>
 
   <section id="arctic-connectivity">
-    <h3 class="text-xl font-semibold flex items-center gap-2">
+    <h3>
       {{ partial "data-icon.html" (dict "name" "globe" "color" "accent" "size" "6") }}
       Arctic Connectivity
     </h3>
-    <p class="text-sm text-neutral-600 dark:text-neutral-300">Cables serving Svalbard and the Arctic region—critical for research, military, and civilian communications in the High North.</p>
-    <div class="mt-3 overflow-x-auto">
-      <table class="min-w-full text-sm">
-        <thead class="text-left">
-          <tr class="border-b border-neutral-200 dark:border-neutral-700">
-            <th class="py-2 pr-4">System</th>
-            <th class="py-2 pr-4">Status</th>
-            <th class="py-2">Notes</th>
+    <p class="sd-network-section-desc">Cables serving Svalbard and the Arctic region—critical for research, military, and civilian communications in the High North.</p>
+    <div class="sd-table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>System</th>
+            <th>Status</th>
+            <th>Notes</th>
           </tr>
         </thead>
         <tbody>
           {{ range sort $arcticCables "name" "asc" }}
             {{ $id := .identifier }}
             {{ $page := site.GetPage (printf "/networks/%s" $id) }}
-            <tr class="border-b border-neutral-100 dark:border-neutral-800">
-              <td class="py-2 pr-4 font-medium">
+            <tr>
+              <td>
                 {{ if $page }}
-                  <a class="hover:underline" href="{{ $page.RelPermalink }}">{{ .name }}</a>
+                  <a href="{{ $page.RelPermalink }}">{{ .name }}</a>
                 {{ else }}
                   {{ .name }}
                 {{ end }}
               </td>
-              <td class="py-2 pr-4">
+              <td>
                 {{ $status := .status | default "active" }}
                 {{ if eq $status "active" }}
-                <span class="badge badge-success badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
+                <span class="sd-status-badge sd-status-active">{{ partial "data-icon.html" (dict "name" "check-circle" "size" "3") }} Active</span>
                 {{ else if eq $status "planned" }}
-                <span class="badge badge-warning badge-sm gap-1">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
+                <span class="sd-status-badge sd-status-planned">{{ partial "data-icon.html" (dict "name" "clock" "size" "3") }} Planned</span>
                 {{ else }}
-                <span class="badge badge-ghost badge-sm">{{ $status }}</span>
+                <span class="sd-status-badge">{{ $status }}</span>
                 {{ end }}
               </td>
-              <td class="py-2">{{ .description | default "—" }}</td>
+              <td>{{ .description | default "—" }}</td>
             </tr>
           {{ end }}
         </tbody>
@@ -260,4 +257,3 @@
   </section>
 
 </div>
-

--- a/layouts/shortcodes/network-map.html
+++ b/layouts/shortcodes/network-map.html
@@ -24,66 +24,73 @@ Usage: {{< network-map>}}
   {{/* connections[] is already normalized in data/networks/networks.json */}}
 
   {{ if $showFiltersBool }}
-  <div id="network-filter-panel" class="mb-6 space-y-4">
-    {{/* Preset filter buttons - stack vertically on mobile */}}
-    <div class="flex flex-col sm:flex-row sm:items-center gap-2">
-      <span class="text-sm font-semibold opacity-70">Filter:</span>
-      <div class="join join-vertical sm:join-horizontal w-full sm:w-auto">
-        <button type="button" class="join-item btn btn-sm btn-active" data-network-preset="all">All Cables</button><button type="button" class="join-item btn btn-sm btn-ghost" data-network-preset="outside">Outside Norway</button><button type="button" class="join-item btn btn-sm btn-ghost" data-network-preset="domestic">Domestic</button><button type="button" class="join-item btn btn-sm btn-ghost" data-network-preset="active">Active Only</button>
+  <div id="network-filter-panel" class="sd-network-filters">
+    <div class="sd-network-filter-group">
+      <span class="sd-network-filter-label">Filter:</span>
+      <div class="sd-filter-pills">
+        <button type="button" class="sd-filter-pill sd-filter-pill-active" data-network-preset="all">All Cables</button>
+        <button type="button" class="sd-filter-pill" data-network-preset="outside">Outside Norway</button>
+        <button type="button" class="sd-filter-pill" data-network-preset="domestic">Domestic</button>
+        <button type="button" class="sd-filter-pill" data-network-preset="active">Active Only</button>
       </div>
     </div>
 
-    {{/* Category checkboxes - horizontal with colors matching map */}}
-    <div class="flex flex-wrap items-center gap-4">
-      <span class="text-sm font-semibold opacity-70">Type:</span>
-      <label class="inline-flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" class="checkbox network-category-checkbox" style="--chkbg: #06b6d4; --chkfg: white; border-color: #06b6d4;" data-category="international-subsea" checked>
-        <span class="text-sm">Outside • Subsea</span>
-      </label>
-      <label class="inline-flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" class="checkbox network-category-checkbox" style="--chkbg: #a855f7; --chkfg: white; border-color: #a855f7;" data-category="international-terrestrial" checked>
-        <span class="text-sm">Outside • Terrestrial</span>
-      </label>
-      <label class="inline-flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" class="checkbox network-category-checkbox" style="--chkbg: #22c55e; --chkfg: white; border-color: #22c55e;" data-category="domestic-subsea" checked>
-        <span class="text-sm">Inside • Subsea</span>
-      </label>
-      <label class="inline-flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" class="checkbox network-category-checkbox" style="--chkbg: #22c55e; --chkfg: white; border-color: #22c55e;" data-category="domestic-terrestrial" checked>
-        <span class="text-sm">Inside • Terrestrial</span>
-      </label>
+    <div class="sd-network-filter-group">
+      <span class="sd-network-filter-label">Type:</span>
+      <div class="sd-network-checkboxes">
+        <label class="sd-network-checkbox-label">
+          <input type="checkbox" class="sd-network-checkbox network-category-checkbox" style="accent-color: #06b6d4;" data-category="international-subsea" checked>
+          <span class="sd-network-checkbox-dot" style="background: #06b6d4;"></span>
+          <span>Outside • Subsea</span>
+        </label>
+        <label class="sd-network-checkbox-label">
+          <input type="checkbox" class="sd-network-checkbox network-category-checkbox" style="accent-color: #a855f7;" data-category="international-terrestrial" checked>
+          <span class="sd-network-checkbox-dot" style="background: #a855f7;"></span>
+          <span>Outside • Terrestrial</span>
+        </label>
+        <label class="sd-network-checkbox-label">
+          <input type="checkbox" class="sd-network-checkbox network-category-checkbox" style="accent-color: #22c55e;" data-category="domestic-subsea" checked>
+          <span class="sd-network-checkbox-dot" style="background: #22c55e;"></span>
+          <span>Inside • Subsea</span>
+        </label>
+        <label class="sd-network-checkbox-label">
+          <input type="checkbox" class="sd-network-checkbox network-category-checkbox" style="accent-color: #22c55e;" data-category="domestic-terrestrial" checked>
+          <span class="sd-network-checkbox-dot" style="background: #22c55e;"></span>
+          <span>Inside • Terrestrial</span>
+        </label>
+      </div>
     </div>
 
-    {{/* Status checkboxes - inline on all sizes */}}
-    <div class="flex flex-wrap items-center gap-4">
-      <span class="text-sm font-semibold opacity-70">Status:</span>
-      <label class="inline-flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" class="checkbox network-status-checkbox" data-status="active" checked>
-        <span class="text-sm">Active</span>
-      </label>
-      <label class="inline-flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" class="checkbox network-status-checkbox" data-status="planned" checked>
-        <span class="text-sm">Planned</span>
-      </label>
-      {{ if $showSimulationBool }}
-      <label class="inline-flex items-center gap-2 cursor-pointer">
-        <input type="checkbox" class="checkbox" id="network-sim-toggle" checked>
-        <span class="text-sm">Show trawler</span>
-      </label>
-      {{ end }}
+    <div class="sd-network-filter-group">
+      <span class="sd-network-filter-label">Status:</span>
+      <div class="sd-network-checkboxes">
+        <label class="sd-network-checkbox-label">
+          <input type="checkbox" class="sd-network-checkbox network-status-checkbox" data-status="active" checked>
+          <span>Active</span>
+        </label>
+        <label class="sd-network-checkbox-label">
+          <input type="checkbox" class="sd-network-checkbox network-status-checkbox" data-status="planned" checked>
+          <span>Planned</span>
+        </label>
+        {{ if $showSimulationBool }}
+        <label class="sd-network-checkbox-label">
+          <input type="checkbox" class="sd-network-checkbox" id="network-sim-toggle" checked>
+          <span>Show trawler</span>
+        </label>
+        {{ end }}
+      </div>
     </div>
   </div>
   {{ end }}
 
-  <div id="network-map-chart"
-    style="width: 100%; height: 700px; background: var(--tw-prose-pre-bg, #f5f5f5); border-radius: 8px;"></div>
+  <div id="network-map-chart" class="sd-network-map-container"></div>
 
-  <div id="network-map-loading" class="text-center py-8">
-    <p class="text-neutral-500">Loading map...</p>
+  <div id="network-map-loading" class="sd-network-map-loading">
+    <p>Loading map...</p>
   </div>
 
-  <div id="network-details" class="mt-6 p-4 bg-neutral-100 dark:bg-neutral-800 rounded-lg" style="display: none;">
-    <h3 id="network-name" class="text-xl font-bold mb-1"></h3>
+  <div id="network-details" class="sd-network-details" style="display: none;">
+    <h3 id="network-name" class="sd-network-details-title"></h3>
     <div id="network-info"></div>
   </div>
 
@@ -616,37 +623,33 @@ Usage: {{< network-map>}}
             if (!detailsDiv || !networkName || !networkInfo) return;
 
             if (data.cable_name) {
-              // Cable details
               var statusBadge = data.cable_status === 'planned'
-                ? '<span class="inline-block px-2 py-1 rounded text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">🔶 Planned</span>'
-                : '<span class="inline-block px-2 py-1 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">✅ Active</span>';
+                ? '<span class="sd-status-badge sd-status-planned">🔶 Planned</span>'
+                : '<span class="sd-status-badge sd-status-active">✅ Active</span>';
 
               var detailsHref = '/networks/' + data.cable_id + '/';
               networkName.innerHTML =
-                '<div class="flex items-start justify-between gap-3 leading-tight">' +
+                '<div class="sd-network-details-header">' +
                   '<span>' + data.cable_name + '</span>' +
-                  '<a href="' + detailsHref + '" class="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap">Open details →</a>' +
+                  '<a href="' + detailsHref + '" class="sd-network-details-link">Open details →</a>' +
                 '</div>';
 
-              var html = '<div class="space-y-2">';
-              // Row 1: status + medium on same line
-              html += '<div class="flex flex-wrap items-center gap-2">';
+              var html = '<div class="sd-network-details-body">';
+              html += '<div class="sd-network-details-meta">';
               html += statusBadge;
-              if (data.cable_medium) html += '<span class="text-xs text-neutral-700 dark:text-neutral-300">• ' + data.cable_medium + '</span>';
+              if (data.cable_medium) html += '<span class="sd-network-details-meta-item">• ' + data.cable_medium + '</span>';
               if (data.cable_length_km) {
-                html += '<span class="text-xs text-neutral-700 dark:text-neutral-300">• ' + data.cable_length_km + ' km</span>';
+                html += '<span class="sd-network-details-meta-item">• ' + data.cable_length_km + ' km</span>';
               }
               html += '</div>';
-              // Row 2: endpoints
               if (data.cable_endpoints) {
-                html += '<div class="text-sm text-neutral-800 dark:text-neutral-200"><strong>Endpoints:</strong> ' + data.cable_endpoints + '</div>';
+                html += '<div class="sd-network-details-endpoints"><strong>Endpoints:</strong> ' + data.cable_endpoints + '</div>';
               }
               html += '</div>';
               networkInfo.innerHTML = html;
             } else if (data.station_city) {
-              // Station details
               networkName.innerHTML = data.name;
-              var html = '<div class="space-y-2">';
+              var html = '<div class="sd-network-details-body">';
               html += '<p><strong>Location:</strong> ' + data.station_city + ', ' + data.station_region + '</p>';
               html += '<p><strong>Connections:</strong> ' + (data.station_cables ? data.station_cables.length : 0) + '</p>';
               html += '</div>';
@@ -694,13 +697,10 @@ Usage: {{< network-map>}}
               } else if (preset === 'active') {
                 selectedStatuses = new Set(['active']);
               }
-              // Update preset button styles
               presetButtons.forEach(function (b) {
-                b.classList.remove('btn-active');
-                b.classList.add('btn-ghost');
+                b.classList.remove('sd-filter-pill-active');
               });
-              btn.classList.add('btn-active');
-              btn.classList.remove('btn-ghost');
+              btn.classList.add('sd-filter-pill-active');
               // Update checkboxes
               categoryCheckboxes.forEach(function (cb) {
                 cb.checked = selectedBuckets.has(cb.getAttribute('data-category'));


### PR DESCRIPTION
## Summary

- Redesign `/networks/` list, single, and shortcode chrome (3 phases) to Stitch `sd-*` section-design system
- Redesign `/countries/` list, single, and bloc pages (3 phases) to Stitch `sd-*` section-design system
- Redesign `/datacenters/` page to match Stitch section-design system

All pages now use gradient heroes, overlapping stat cards, `sd-*` design tokens, inline metadata grids (replacing sidebar cards on detail pages), `sd-filter-pill` badges for topics/tags, and `sovereignsky-footer.html`.

## Changes

- `layouts/networks/list.html` — full rewrite to section-design
- `layouts/networks/single.html` — full rewrite, sidebar → inline metadata grid
- `layouts/shortcodes/network-data.html` — section IDs + table styling
- `layouts/shortcodes/network-map.html` — filter pills, container chrome
- `layouts/countries/list.html` — full rewrite to section-design
- `layouts/countries/single.html` — full rewrite, sidebar → inline metadata grid
- `layouts/countries/bloc.html` — full rewrite to section-design
- `layouts/datacenters/list.html` — section-design rewrite
- `assets/css/custom.css` — added `sd-networks`, `sd-countries`, country grid/card styles

## Test plan

- [ ] Hugo build succeeds in CI
- [ ] `/networks/` list page renders with hero, stat cards, data tables
- [ ] `/networks/{slug}/` detail pages render with metadata grid, connection map
- [ ] `/countries/` list page renders with hero, stat cards, country grid
- [ ] `/countries/{slug}/` detail pages render with metadata grid
- [ ] `/countries/{slug}/blocs/{bloc}/` bloc pages render with stat cards, member grids
- [ ] `/datacenters/` page renders correctly
- [ ] ECharts interactive maps still work (networks, jurisdictions)
- [ ] Light and dark mode both work across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)