### PR TITLE
Redesign law single pages to Stitch design system

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3030,6 +3030,84 @@ details[open] .details-marker {
   }
 }
 
+/* Jurisdiction-map stats — 4 columns, no hero overlap */
+.sd-jurisdiction-map-stats {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  padding: 0;
+}
+
+@media (min-width: 768px) {
+  .sd-jurisdiction-map-stats {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+/* Jurisdiction-map filters — reuse sd-laws filter styles */
+#jurisdiction-map [data-filter-group] {
+  margin-bottom: 0.75rem;
+}
+
+#jurisdiction-map .sd-laws-filter-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+#jurisdiction-map .sd-laws-filter-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.6;
+  color: var(--sd-on-surface);
+}
+
+#jurisdiction-map .sd-laws-filter-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+#jurisdiction-map .sd-laws-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--sd-outline-variant);
+  background: transparent;
+  color: var(--sd-on-surface);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+#jurisdiction-map .sd-laws-filter-btn:hover {
+  background: var(--sd-surface-container-low);
+}
+
+#jurisdiction-map .sd-laws-filter-btn--active {
+  background: var(--sd-primary);
+  color: var(--sd-on-primary);
+  border-color: var(--sd-primary);
+}
+
+#jurisdiction-map .sd-laws-filter-btn--active:hover {
+  opacity: 0.9;
+}
+
+#jurisdiction-map .sd-laws-filter-btn--clear {
+  border: none;
+  opacity: 0.7;
+}
+
+#jurisdiction-map .sd-laws-filter-btn--clear:hover {
+  opacity: 1;
+  background: transparent;
+}
+
 /* Countries grid */
 .sd-country-grid {
   display: grid;

--- a/docs/ai-developer/plans/active/PLAN-laws-single-redesign.md
+++ b/docs/ai-developer/plans/active/PLAN-laws-single-redesign.md
@@ -1,0 +1,107 @@
+# Feature: Redesign individual law pages to Stitch design language
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: In Progress
+
+**Goal**: Replace the old sidebar-based `common-single-page.html` layout on individual law pages with the Stitch section-design pattern matching the countries/networks single pages.
+
+**Last Updated**: 2026-04-13
+
+---
+
+## Overview
+
+The `/laws/{law-name}/` pages currently use `common-single-page.html` which renders a traditional Blowfish sidebar layout with DaisyUI cards. The rest of the site (countries, networks, datacenters, laws list) has been redesigned to use the Stitch section-design system with gradient hero, inline stat cards, and full-width content.
+
+**Current state**: `layouts/laws/single.html` delegates entirely to `common-single-page.html` with 7 sidebar card partials.
+
+**Target state**: Inline Stitch template matching `layouts/countries/single.html` pattern — gradient hero, metadata stat cards, full-width content body.
+
+**Reference templates**: `layouts/countries/single.html`, `layouts/countries/bloc.html`
+
+---
+
+## Phase 1: Rewrite single.html to Stitch pattern — DONE
+
+Convert `layouts/laws/single.html` from the `common-single-page.html` partial to an inline Stitch section-design template.
+
+### Tasks
+
+- [x] 1.1 Replace entire `single.html` with inline Stitch template structure
+  - Wrap in `<article class="sd-laws section-design">`
+  - Add gradient hero (`sd-events-hero`) with breadcrumbs, badge ("Legislation"), title, alternate name, and "Official text" external link button
+  - Add metadata stat cards section (`sd-events-stats`) with 3 cards:
+    - **Details**: Year, Type (with emoji), Gov Access, Data Protection, boolean flags
+    - **Applies To**: Jurisdiction countries/blocs with flags and links
+    - **Relevant For**: Audience personas with links
+  - Add main content section (`sd-blog-feed` > `sd-dc-content`) with:
+    - Abstract section
+    - Summary section
+    - Table of contents
+    - Main markdown content
+    - Related Laws section (conflicts, complements, implements, etc.)
+    - Same Jurisdiction laws
+    - Topics and Tags as pill links
+    - Back link to /laws/
+  - Add floating TOC partial
+
+- [x] 1.2 Inline the law type emoji/label logic (from sidebar/laws-details-card.html)
+- [x] 1.3 Inline the jurisdiction resolution logic (from sidebar/laws-appliesto.html)
+- [x] 1.4 Inline the related laws logic (from sidebar/laws-related-card.html)
+
+### Validation
+
+- Hugo build succeeds
+- Page renders with gradient hero, stat cards, full-width content
+- All metadata visible (year, type, access, protection, flags, jurisdictions, audience)
+- Related laws links work
+- External "Official text" link works
+
+---
+
+## Phase 2: CSS additions if needed — DONE (no changes needed)
+
+### Tasks
+
+- [x] 2.1 Check if any law-specific CSS classes are needed beyond existing `.sd-laws` styles — None needed, reuses existing `sd-events-stats`, `sd-events-stat-card`, `sd-filter-pills` etc.
+- [x] 2.2 Add any missing responsive/dark-mode styles for the new layout — Not needed, inherits from shared section-design styles
+
+### Validation
+
+- Dark mode renders correctly
+- Mobile layout is responsive
+- No visual regressions on laws list page
+
+---
+
+## Phase 3: Commit, push, and verify — TODO
+
+### Tasks
+
+- [ ] 3.1 Commit changes on feature branch
+- [ ] 3.2 Push and create PR if needed
+- [ ] 3.3 Verify on live site after CI deploy
+
+### Validation
+
+- Live page matches design intent
+- All interactive elements work
+
+---
+
+## Files to Modify
+
+- `layouts/laws/single.html` — Primary template rewrite
+- `assets/css/custom.css` — CSS additions if needed
+
+## Files for Reference (read-only)
+
+- `layouts/countries/single.html` — Target pattern
+- `layouts/partials/sidebar/laws-details-card.html` — Details metadata logic
+- `layouts/partials/sidebar/laws-appliesto.html` — Jurisdiction logic
+- `layouts/partials/sidebar/laws-related-card.html` — Related laws logic
+- `layouts/partials/sidebar/common-audience-card.html` — Audience logic
+- `content/laws/gdpr/index.md` — Example law frontmatter

--- a/layouts/laws/single.html
+++ b/layouts/laws/single.html
@@ -1,23 +1,376 @@
 {{ define "main" }}
 {{ .Scratch.Set "scope" "single" }}
 
-{{ partial "common-single-page.html" (dict
-    "page" .
-    "icon" "scale"
-    "section" "Laws"
-    "sectionUrl" "/laws/"
-    "headerDescription" .Params.alternateName
-    "externalUrl" .Params.sourceUrl
-    "externalLabel" "Official text"
-    "sidebarCards" (slice
-        "sidebar/laws-details-card.html"
-        "sidebar/laws-appliesto.html"
-        "sidebar/common-audience-card.html"
-        "sidebar/common-topics-card.html"
-        "sidebar/common-tags-card.html"
-        "sidebar/laws-related-card.html"
-        "sidebar/common-related-card.html"
-    )
-) }}
+{{/* ── Law metadata ── */}}
+{{ $lawId := .Params.identifier | default "" }}
+{{ $year := .Params.legislationDate | default "" }}
+{{ $alternateName := .Params.alternateName | default "" }}
+{{ $sourceUrl := .Params.sourceUrl | default "" }}
+{{ $category := .Params.category | default "privacy" }}
+{{ $governmentAccess := .Params.governmentAccess | default "none" }}
+{{ $dataProtection := .Params.dataProtection | default "none" }}
+{{ $extraterritorial := .Params.extraterritorial | default false }}
+{{ $requiresLocalization := .Params.requiresLocalization | default false }}
+{{ $requiresBackdoor := .Params.requiresBackdoor | default false }}
+{{ $appliesTo := .Params.legislationJurisdiction | default (slice) }}
+{{ $audienceParams := .Params.audience | default (slice) }}
+{{ $relatedLawsData := .Params.isRelatedTo | default dict }}
 
+{{/* ── Law type styling ── */}}
+{{ $typeEmoji := "" }}
+{{ $typeLabel := $category }}
+{{ if eq $category "privacy" }}{{ $typeEmoji = "🛡️" }}{{ $typeLabel = "Privacy" }}
+{{ else if eq $category "access" }}{{ $typeEmoji = "🔓" }}{{ $typeLabel = "Access" }}
+{{ else if eq $category "surveillance" }}{{ $typeEmoji = "👁️" }}{{ $typeLabel = "Surveillance" }}
+{{ else if eq $category "localization" }}{{ $typeEmoji = "📍" }}{{ $typeLabel = "Localization" }}
+{{ else if eq $category "security" }}{{ $typeEmoji = "🔒" }}{{ $typeLabel = "Security" }}
+{{ else if eq $category "sector" }}{{ $typeEmoji = "📋" }}{{ $typeLabel = "Sector" }}
+{{ end }}
+
+{{/* ── Government access label ── */}}
+{{ $accessLabel := $governmentAccess }}
+{{ if eq $governmentAccess "broad" }}{{ $accessLabel = "Broad" }}
+{{ else if eq $governmentAccess "targeted" }}{{ $accessLabel = "Targeted" }}
+{{ else if eq $governmentAccess "limited" }}{{ $accessLabel = "Limited" }}
+{{ else if eq $governmentAccess "none" }}{{ $accessLabel = "None" }}
+{{ end }}
+
+{{/* ── Data protection label ── */}}
+{{ $protectionLabel := $dataProtection }}
+{{ if eq $dataProtection "strong" }}{{ $protectionLabel = "Strong" }}
+{{ else if eq $dataProtection "moderate" }}{{ $protectionLabel = "Moderate" }}
+{{ else if eq $dataProtection "weak" }}{{ $protectionLabel = "Weak" }}
+{{ else if eq $dataProtection "none" }}{{ $protectionLabel = "None" }}
+{{ end }}
+
+{{/* ── Jurisdiction resolution ── */}}
+{{ $regionsById := dict }}
+{{ $countries := site.Data.countries.countries.itemListElement | default (slice) }}
+{{ range $countries }}
+  {{ $regionsById = merge $regionsById (dict .identifier .) }}
+{{ end }}
+{{ $blocsById := dict }}
+{{ range (site.Data.blocs.blocs.itemListElement | default (slice)) }}
+  {{ $blocsById = merge $blocsById (dict .identifier .) }}
+{{ end }}
+
+{{ $appliesToItems := slice }}
+{{ range $appliesTo }}
+  {{ $id := . }}
+  {{ $name := $id }}
+  {{ $flag := "" }}
+  {{ $slug := "" }}
+  {{ $isBloc := false }}
+  {{ $region := index $regionsById $id }}
+  {{ if $region }}
+    {{ $name = $region.name | default $id }}
+    {{ $flag = $region.flag | default "" }}
+    {{ $slug = $region.slug | default "" }}
+  {{ else }}
+    {{ $bloc := index $blocsById $id }}
+    {{ if $bloc }}
+      {{ $name = $bloc.name | default $id }}
+      {{ $flag = $bloc.flag | default "" }}
+      {{ $slug = $bloc.slug | default $bloc.identifier | default $id }}
+      {{ $isBloc = true }}
+    {{ end }}
+  {{ end }}
+  {{ $appliesToItems = $appliesToItems | append (dict "id" $id "name" $name "flag" $flag "slug" $slug "isBloc" $isBloc) }}
+{{ end }}
+
+{{/* ── Audience resolution ── */}}
+{{ $audienceList := site.Data.audience.audience.itemListElement | default (slice) }}
+
+{{/* ── Related laws lookup ── */}}
+{{ $lawsById := dict }}
+{{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
+  {{ $lawsById = merge $lawsById (dict .identifier .) }}
+{{ end }}
+
+{{/* ── Same jurisdiction laws ── */}}
+{{ $sameJurisdictionLaws := slice }}
+{{ if gt (len $appliesTo) 0 }}
+  {{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
+    {{ $otherLaw := . }}
+    {{ if ne $otherLaw.identifier $lawId }}
+      {{ $found := false }}
+      {{ range $otherLaw.legislationJurisdiction }}
+        {{ $otherId := . }}
+        {{ range $appliesTo }}
+          {{ if eq . $otherId }}{{ $found = true }}{{ end }}
+        {{ end }}
+      {{ end }}
+      {{ if $found }}
+        {{ $sameJurisdictionLaws = $sameJurisdictionLaws | append $otherLaw }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<article class="sd-laws section-design">
+
+  {{/* ============================================================
+       HERO
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        {{/* Breadcrumbs */}}
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/laws/" style="color: inherit; text-decoration: none; opacity: 0.7;">Laws</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ .Title }}</span>
+          </span>
+        </nav>
+
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Legislation</span>
+        </div>
+
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">
+          {{ $typeEmoji }} {{ .Title }}
+        </h1>
+
+        {{ if $alternateName }}
+        <p class="sd-events-hero-description">{{ $alternateName }}</p>
+        {{ else }}
+        {{ with .Description }}
+        <p class="sd-events-hero-description">{{ . }}</p>
+        {{ end }}
+        {{ end }}
+
+        {{ if $sourceUrl }}
+        <div style="margin-top: 1.25rem;">
+          <a href="{{ $sourceUrl }}" target="_blank" rel="noopener noreferrer"
+             style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1.25rem; border-radius: 0.5rem; background: rgba(255,255,255,0.15); color: inherit; text-decoration: none; font-size: 0.875rem; font-weight: 500; backdrop-filter: blur(4px); border: 1px solid rgba(255,255,255,0.2); transition: background 0.2s;">
+            Official text ↗
+          </a>
+        </div>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       METADATA CARDS
+       ============================================================ */}}
+  <section class="sd-events-stats">
+
+    {{/* Details card */}}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Details</span>
+      <dl style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.8;">
+        {{ if $year }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Year</dt>
+          <dd style="font-weight: 500;">{{ $year }}</dd>
+        </div>
+        {{ end }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Type</dt>
+          <dd style="font-weight: 500;">{{ $typeEmoji }} {{ $typeLabel }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Gov Access</dt>
+          <dd style="font-weight: 500;">{{ $accessLabel }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Data Protection</dt>
+          <dd style="font-weight: 500;">{{ $protectionLabel }}</dd>
+        </div>
+        {{ if or $extraterritorial $requiresLocalization $requiresBackdoor }}
+        <div style="margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+          {{ if $extraterritorial }}
+          <div>🌍 Extraterritorial</div>
+          {{ end }}
+          {{ if $requiresLocalization }}
+          <div>📍 Requires Localization</div>
+          {{ end }}
+          {{ if $requiresBackdoor }}
+          <div style="color: var(--sd-error, #ba1a1a);">🔑 Requires Backdoor</div>
+          {{ end }}
+        </div>
+        {{ end }}
+      </dl>
+    </div>
+
+    {{/* Applies To card */}}
+    {{ if gt (len $appliesToItems) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Applies To</span>
+      <div style="margin-top: 0.5rem;" class="sd-filter-pills">
+        {{ range $appliesToItems }}
+        <a href="/countries/{{ .slug }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+          {{ with .flag }}{{ . }} {{ end }}{{ .name }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+
+    {{/* Relevant For card */}}
+    {{ if gt (len $audienceParams) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Relevant For</span>
+      <div style="margin-top: 0.5rem;" class="sd-filter-pills">
+        {{ range $audienceParams }}
+        {{ $audienceId := . }}
+        {{ $audience := dict }}
+        {{ range $audienceList }}
+          {{ if eq .identifier $audienceId }}{{ $audience = . }}{{ end }}
+        {{ end }}
+        {{ $name := $audience.name | default ($audienceId | humanize | title) }}
+        <a href="/personas/{{ $audienceId }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+          {{ $name }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+
+  </section>
+
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* Abstract */}}
+      {{ with .Params.abstract }}
+      <div style="margin-bottom: 1.5rem;">
+        <h2 id="abstract" style="font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem;">Abstract</h2>
+        <p style="font-size: 1rem; color: var(--sd-on-surface-variant); line-height: 1.7;">{{ . }}</p>
+      </div>
+      {{ end }}
+
+      {{/* Summary */}}
+      {{ with .Params.summary }}
+      <div style="margin-bottom: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <h2 id="summary" style="font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem;">Summary</h2>
+        <p style="font-size: 1.0625rem; color: var(--sd-on-surface-variant); line-height: 1.7;">{{ . }}</p>
+      </div>
+      {{ end }}
+
+      {{/* Main article content */}}
+      {{ if .Content }}
+      <div style="margin-bottom: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <div class="article-content prose dark:prose-invert max-w-none">
+          {{ .Content }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* ── Related Laws ── */}}
+      {{ $hasSemanticRelations := gt (len $relatedLawsData) 0 }}
+      {{ if or $hasSemanticRelations (gt (len $sameJurisdictionLaws) 0) }}
+      <div style="margin-bottom: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <h2 id="related-laws" style="font-size: 1.25rem; font-weight: 600; margin-bottom: 1rem;">Related Laws</h2>
+
+        {{ if $hasSemanticRelations }}
+          {{/* Relationship type template — renders a labeled group of law links */}}
+          {{ $relationTypes := slice
+            (dict "key" "conflicts_with" "label" "Conflicts with" "color" "var(--sd-error, #ba1a1a)")
+            (dict "key" "complements" "label" "Works with" "color" "")
+            (dict "key" "implements" "label" "Implements" "color" "")
+            (dict "key" "implemented_by" "label" "Implemented by" "color" "")
+            (dict "key" "extends" "label" "Extends" "color" "")
+            (dict "key" "extended_by" "label" "Extended by" "color" "")
+            (dict "key" "amends" "label" "Amends" "color" "")
+            (dict "key" "amended_by" "label" "Amended by" "color" "")
+            (dict "key" "succeeds" "label" "Succeeds" "color" "")
+            (dict "key" "succeeded_by" "label" "Succeeded by" "color" "")
+            (dict "key" "interprets" "label" "Interprets" "color" "")
+            (dict "key" "interpreted_by" "label" "Interpreted by" "color" "")
+          }}
+
+          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr)); gap: 1rem;">
+            {{ range $relationTypes }}
+              {{ $relLabel := .label }}
+              {{ $relColor := .color }}
+              {{ $items := index $relatedLawsData .key }}
+              {{ if $items }}
+              <div>
+                <h3 style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.7; margin-bottom: 0.5rem;{{ if $relColor }} color: {{ $relColor }};{{ end }}">{{ $relLabel }}</h3>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                  {{ range $items }}
+                  {{ $lawData := index $lawsById .identifier }}
+                  {{ $tooltip := "" }}
+                  {{ with $lawData }}{{ $tooltip = .alternateName | default .name }}{{ end }}
+                  <li style="margin-bottom: 0.25rem;">
+                    <a href="/laws/{{ .identifier }}/" title="{{ $tooltip }}" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">
+                      {{ .name }} <span style="opacity: 0.5;">({{ .legislationDate }})</span>
+                    </a>
+                  </li>
+                  {{ end }}
+                </ul>
+              </div>
+              {{ end }}
+            {{ end }}
+          </div>
+        {{ end }}
+
+        {{/* Same jurisdiction */}}
+        {{ if gt (len $sameJurisdictionLaws) 0 }}
+        <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+          <h3 style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.7; margin-bottom: 0.5rem;">Same Jurisdiction</h3>
+          <div class="sd-filter-pills">
+            {{ range first 8 $sameJurisdictionLaws }}
+            <a href="/laws/{{ .identifier }}/" title="{{ .alternateName | default .name }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+              {{ .name }} <span style="opacity: 0.5;">({{ .legislationDate }})</span>
+            </a>
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
+      </div>
+      {{ end }}
+
+      {{/* ── Topics ── */}}
+      {{ with .Params.topics }}
+      <div style="margin-bottom: 1rem;">
+        <h3 style="font-size: 0.875rem; font-weight: 600; opacity: 0.7; margin-bottom: 0.5rem;">Topics</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="/topics/{{ . }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ . | humanize | title }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* ── Tags ── */}}
+      {{ with .GetTerms "tags" }}
+      <div style="margin-bottom: 1.5rem;">
+        <h3 style="font-size: 0.875rem; font-weight: 600; opacity: 0.7; margin-bottom: 0.5rem;">Tags</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="{{ .RelPermalink }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ .LinkTitle }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* Back link */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/laws/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all laws</a>
+      </div>
+
+    </div>
+  </section>
+
+</article>
+
+{{/* Floating TOC */}}
+{{ $tocSections := slice
+    (dict "id" "abstract" "title" "Abstract" "icon" "📄")
+    (dict "id" "summary" "title" "Summary" "icon" "📝")
+    (dict "id" "related-laws" "title" "Related" "icon" "⚖️")
+}}
+{{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/shortcodes/jurisdiction-map.html
+++ b/layouts/shortcodes/jurisdiction-map.html
@@ -116,74 +116,76 @@
 {{ end }}
 
 <div id="jurisdiction-map">
-<div class="not-prose stats stats-vertical sm:stats-horizontal shadow-lg w-full mb-8 bg-base-100">
-  <div class="stat">
-    <div class="stat-figure text-primary">
-      {{ partial "data-icon.html" (dict "name" "globe" "color" "primary" "size" "8") }}
+<section class="not-prose sd-events-stats sd-jurisdiction-map-stats">
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Countries Tracked</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $totalCountries }}</span>
+      <span class="sd-events-stat-desc">Jurisdictions monitored</span>
     </div>
-    <div class="stat-title">Countries Tracked</div>
-    <div class="stat-value text-primary">{{ $totalCountries }}</div>
-    <div class="stat-desc">Jurisdictions monitored</div>
   </div>
-  <div class="stat">
-    <div class="stat-figure text-accent">
-      {{ partial "data-icon.html" (dict "name" "users" "color" "accent" "size" "8") }}
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Regional Blocs</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $totalBlocs }}</span>
+      <span class="sd-events-stat-desc">Trade & legal frameworks</span>
     </div>
-    <div class="stat-title">Regional Blocs</div>
-    <div class="stat-value text-accent">{{ $totalBlocs }}</div>
-    <div class="stat-desc">Trade & legal frameworks</div>
   </div>
-  <div class="stat">
-    <div class="stat-figure text-success">
-      {{ partial "data-icon.html" (dict "name" "check-circle" "color" "success" "size" "8") }}
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Low Risk</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $lowRisk }}</span>
+      <span class="sd-events-stat-desc">Safe jurisdictions</span>
     </div>
-    <div class="stat-title">Low Risk</div>
-    <div class="stat-value text-success">{{ $lowRisk }}</div>
-    <div class="stat-desc">Safe jurisdictions</div>
   </div>
-  <div class="stat">
-    <div class="stat-figure text-error">
-      {{ partial "data-icon.html" (dict "name" "alert-triangle" "color" "error" "size" "8") }}
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Elevated+ Risk</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $elevatedRisk }}</span>
+      <span class="sd-events-stat-desc">Require caution</span>
     </div>
-    <div class="stat-title">Elevated+ Risk</div>
-    <div class="stat-value text-error">{{ $elevatedRisk }}</div>
-    <div class="stat-desc">Require caution</div>
   </div>
-</div>
+</section>
 
 
 {{/* Risk Level Filter */}}
-<div class="not-prose flex flex-wrap items-center gap-2 mb-4">
-  <span class="text-sm font-semibold opacity-70">Risk:</span>
-  <div class="join" id="laws-risk-chips" data-filter-group="risk">
-    <button class="join-item btn btn-sm btn-active" data-filter="risk" data-value="all">All</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="low">✅ Low</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="moderate">⚠️ Moderate</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="elevated">🔶 Elevated</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="high">🚨 High</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="sanctioned">⛔ Sanctioned</button>
+<div class="not-prose" data-filter-group="risk">
+  <div class="sd-laws-filter-header">
+    <span class="sd-laws-filter-label">Risk:</span>
+    <button class="sd-laws-filter-btn sd-laws-filter-btn--active" data-filter="risk" data-value="all">All</button>
+  </div>
+  <div class="sd-laws-filter-options" id="laws-risk-chips">
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="low">✅ Low</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="moderate">⚠️ Moderate</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="elevated">🔶 Elevated</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="high">🚨 High</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="sanctioned">⛔ Sanctioned</button>
   </div>
 </div>
 
 {{/* Bloc Filter */}}
-<div class="not-prose flex flex-wrap items-center gap-2 mb-4">
-  <span class="text-sm font-semibold opacity-70">Bloc:</span>
-  <div class="join" id="laws-bloc-chips" data-filter-group="bloc">
-    <button class="join-item btn btn-sm btn-active" data-filter="bloc" data-value="all">All</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="eu">🇪🇺 EU</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="eea">🇪🇺 EEA</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="five-eyes">👁️ Five Eyes</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="adequacy">✓ Adequacy</button>
+<div class="not-prose" data-filter-group="bloc">
+  <div class="sd-laws-filter-header">
+    <span class="sd-laws-filter-label">Bloc:</span>
+    <button class="sd-laws-filter-btn sd-laws-filter-btn--active" data-filter="bloc" data-value="all">All</button>
+  </div>
+  <div class="sd-laws-filter-options" id="laws-bloc-chips">
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="eu">🇪🇺 EU</button>
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="eea">🇪🇺 EEA</button>
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="five-eyes">👁️ Five Eyes</button>
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="adequacy">✓ Adequacy</button>
   </div>
 </div>
 
 {{/* Features Filter */}}
-<div class="not-prose flex flex-wrap items-center gap-2 mb-6">
-  <span class="text-sm font-semibold opacity-70">Features:</span>
-  <div class="flex flex-wrap gap-2" data-filter-group="features">
-    <button class="btn btn-sm btn-ghost gap-1" id="laws-has-dc" data-filter="datacenters" data-value="true">🏢 Has Datacenters</button>
+<div class="not-prose" data-filter-group="features">
+  <div class="sd-laws-filter-header">
+    <span class="sd-laws-filter-label">Features:</span>
   </div>
-  <button id="laws-map-reset" class="btn btn-sm btn-ghost ml-auto">Reset filters</button>
+  <div class="sd-laws-filter-options">
+    <button class="sd-laws-filter-btn" id="laws-has-dc" data-filter="datacenters" data-value="true">🏢 Has Datacenters</button>
+    <button class="sd-laws-filter-btn sd-laws-filter-btn--clear" id="laws-map-reset">Reset filters</button>
+  </div>
 </div>
 
 <div id="jurisdiction-map-chart" class="not-prose" style="width: 100%; height: 520px; background: var(--tw-prose-pre-bg, #f5f5f5); border-radius: 12px;"></div>
@@ -327,14 +329,21 @@
       var blocsById = blocById();
 
       function setActiveButton(groupEl, value) {
-        groupEl.querySelectorAll('button').forEach(function(b) {
-          b.classList.remove('btn-active');
-          b.classList.add('btn-ghost');
+        groupEl.querySelectorAll('button[data-filter]').forEach(function(b) {
+          b.classList.remove('sd-laws-filter-btn--active');
         });
-        var target = groupEl.querySelector('button[data-value="' + value + '"]') || groupEl.querySelector('button[data-value="all"]');
-        if (target) {
-          target.classList.add('btn-active');
-          target.classList.remove('btn-ghost');
+        var container = groupEl.closest('[data-filter-group]');
+        var allBtn = container ? container.querySelector('.sd-laws-filter-header button[data-value="all"]') : null;
+        if (allBtn) allBtn.classList.remove('sd-laws-filter-btn--active');
+        if (value === 'all' && allBtn) {
+          allBtn.classList.add('sd-laws-filter-btn--active');
+        } else {
+          var target = groupEl.querySelector('button[data-value="' + value + '"]');
+          if (target) {
+            target.classList.add('sd-laws-filter-btn--active');
+          } else if (allBtn) {
+            allBtn.classList.add('sd-laws-filter-btn--active');
+          }
         }
       }
 
@@ -365,11 +374,9 @@
           dcBtn.addEventListener('click', function() {
             hasDatacentersOnly = !hasDatacentersOnly;
             if (hasDatacentersOnly) {
-              dcBtn.classList.add('btn-active');
-              dcBtn.classList.remove('btn-ghost');
+              dcBtn.classList.add('sd-laws-filter-btn--active');
             } else {
-              dcBtn.classList.remove('btn-active');
-              dcBtn.classList.add('btn-ghost');
+              dcBtn.classList.remove('sd-laws-filter-btn--active');
             }
             focusedIds = null;
             renderAll();
@@ -383,11 +390,9 @@
         var dcBtn = document.getElementById('laws-has-dc');
         if (dcBtn) {
           if (hasDatacentersOnly) {
-            dcBtn.classList.add('btn-active');
-            dcBtn.classList.remove('btn-ghost');
+            dcBtn.classList.add('sd-laws-filter-btn--active');
           } else {
-            dcBtn.classList.remove('btn-active');
-            dcBtn.classList.add('btn-ghost');
+            dcBtn.classList.remove('sd-laws-filter-btn--active');
           }
         }
       }


### PR DESCRIPTION
## Summary

- Redesign individual law pages (`/laws/{law-name}/`) from old sidebar-based `common-single-page.html` layout to inline Stitch section-design pattern
- Matches the design language used on countries, networks, and datacenters single pages
- Adds gradient hero with breadcrumbs, 3 metadata stat cards (Details, Applies To, Relevant For), and full-width content with related laws, topics, and tags

## Test plan

- [ ] Verify law pages render with gradient hero and stat cards (e.g. `/laws/gdpr/`, `/laws/cloud-act/`)
- [ ] Verify "Official text" external link button works
- [ ] Verify jurisdiction links in "Applies To" card navigate correctly
- [ ] Verify "Related Laws" section shows all relationship types
- [ ] Verify topics and tags render as pill links
- [ ] Verify mobile responsive layout
- [ ] Verify dark mode rendering
- [ ] Verify no regressions on laws list page (`/laws/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)