### PR TITLE
Redesign datacenter & law pages to Stitch design system

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -3030,6 +3030,84 @@ details[open] .details-marker {
   }
 }
 
+/* Jurisdiction-map stats — 4 columns, no hero overlap */
+.sd-jurisdiction-map-stats {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  padding: 0;
+}
+
+@media (min-width: 768px) {
+  .sd-jurisdiction-map-stats {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+/* Jurisdiction-map filters — reuse sd-laws filter styles */
+#jurisdiction-map [data-filter-group] {
+  margin-bottom: 0.75rem;
+}
+
+#jurisdiction-map .sd-laws-filter-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+#jurisdiction-map .sd-laws-filter-label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  opacity: 0.6;
+  color: var(--sd-on-surface);
+}
+
+#jurisdiction-map .sd-laws-filter-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+#jurisdiction-map .sd-laws-filter-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 0.8125rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--sd-outline-variant);
+  background: transparent;
+  color: var(--sd-on-surface);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+#jurisdiction-map .sd-laws-filter-btn:hover {
+  background: var(--sd-surface-container-low);
+}
+
+#jurisdiction-map .sd-laws-filter-btn--active {
+  background: var(--sd-primary);
+  color: var(--sd-on-primary);
+  border-color: var(--sd-primary);
+}
+
+#jurisdiction-map .sd-laws-filter-btn--active:hover {
+  opacity: 0.9;
+}
+
+#jurisdiction-map .sd-laws-filter-btn--clear {
+  border: none;
+  opacity: 0.7;
+}
+
+#jurisdiction-map .sd-laws-filter-btn--clear:hover {
+  opacity: 1;
+  background: transparent;
+}
+
 /* Countries grid */
 .sd-country-grid {
   display: grid;

--- a/docs/ai-developer/plans/active/PLAN-datacenter-singles-redesign.md
+++ b/docs/ai-developer/plans/active/PLAN-datacenter-singles-redesign.md
@@ -1,0 +1,96 @@
+# Feature: Redesign datacenter single/country pages to Stitch design
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: Active
+
+**Goal**: Convert datacenter `single.html` and `country.html` templates from the old sidebar layout to the Stitch section-design system, matching `countries/single.html` and `laws/single.html`.
+
+**Last Updated**: 2026-04-14
+
+---
+
+## Overview
+
+Two datacenter detail templates still use the old sidebar-based layout with DaisyUI cards:
+
+- **`single.html`** — Provider detail pages (e.g. `/datacenters/azure/`). Uses `common-detail-header.html` + sidebar with inline card logic. Reads from `site.Data.datacenters` for provider metadata.
+- **`country.html`** — Country datacenter pages (e.g. `/datacenters/germany/`). Uses `common-detail-header.html` + sidebar with partial cards. Reads from `site.Data.countries` and `site.Data.datacenters`.
+
+**Note**: `provider.html` already uses a modernized partial-based layout and is not in scope. `list.html` was already redesigned in `PLAN-datacenters-redesign.md`.
+
+**Target pattern**: `layouts/countries/single.html` — Stitch hero + inline metadata grid + full-width content + floating TOC + footer. No sidebar.
+
+**Key transformation**:
+1. Replace `common-detail-header.html` with `.sd-events-hero` gradient hero (breadcrumbs, badge, title)
+2. Replace sidebar cards with `.sd-events-stats` inline metadata grid
+3. Wrap content in `.sd-blog-feed > .sd-dc-content`
+4. Add floating TOC and `sovereignsky-footer.html`
+5. Remove all sidebar partial calls
+
+---
+
+## Phase 1: Redesign `single.html` (Provider Detail Page) — DONE
+
+### Tasks
+
+- [x] 1.1 Replace `common-detail-header.html` with Stitch hero section ✓
+- [x] 1.2 Build metadata grid with 3 cards: Provider Details, Countries, Compare ✓
+- [x] 1.3 Build content section with external link, content, tags, back link ✓
+- [x] 1.4 Add floating TOC and `sovereignsky-footer.html` ✓
+- [x] 1.5 Remove all sidebar partial calls ✓
+- [x] 1.6 Preserve all existing data resolution logic ✓
+
+### Validation
+
+Hugo template syntax is correct. Page structure matches `countries/single.html` pattern.
+
+---
+
+## Phase 2: Redesign `country.html` (Country Datacenter Page) — DONE
+
+### Tasks
+
+- [x] 2.1 Replace `common-detail-header.html` with Stitch hero section ✓
+- [x] 2.2 Build metadata grid with 3 cards: Region Details, Memberships, Top Providers ✓
+- [x] 2.3 Build content section with summary, map, providers, regions, laws link ✓
+- [x] 2.4 Add floating TOC and `sovereignsky-footer.html` ✓
+- [x] 2.5 Remove all sidebar partial calls and DaisyUI card markup ✓
+
+### Validation
+
+Hugo template syntax is correct. Page structure matches `countries/single.html` pattern.
+
+---
+
+## Phase 3: Commit & Push
+
+### Tasks
+
+- [ ] 3.1 Commit changes on feature branch
+- [ ] 3.2 Push branch and create PR
+- [ ] 3.3 Verify on live site after CI deploy
+
+### Validation
+
+CI passes, pages render correctly on live site.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `single.html` uses Stitch hero, inline metadata grid, and full-width content (no sidebar)
+- [ ] `country.html` uses Stitch hero, inline metadata grid, and full-width content (no sidebar)
+- [ ] All existing data (provider details, countries, risk levels, comparisons) is preserved
+- [ ] Map shortcodes render correctly on country pages
+- [ ] Inline partials (providers, regions) still work
+- [ ] Floating TOC navigation works
+- [ ] Dark mode renders correctly
+- [ ] Site builds without errors
+
+## Files to Modify
+
+- `layouts/datacenters/single.html`
+- `layouts/datacenters/country.html`

--- a/docs/ai-developer/plans/active/PLAN-laws-single-redesign.md
+++ b/docs/ai-developer/plans/active/PLAN-laws-single-redesign.md
@@ -1,0 +1,107 @@
+# Feature: Redesign individual law pages to Stitch design language
+
+> **IMPLEMENTATION RULES:** Before implementing this plan, read and follow:
+> - [WORKFLOW.md](../../WORKFLOW.md) - The implementation process
+> - [PLANS.md](../../PLANS.md) - Plan structure and best practices
+
+## Status: In Progress
+
+**Goal**: Replace the old sidebar-based `common-single-page.html` layout on individual law pages with the Stitch section-design pattern matching the countries/networks single pages.
+
+**Last Updated**: 2026-04-13
+
+---
+
+## Overview
+
+The `/laws/{law-name}/` pages currently use `common-single-page.html` which renders a traditional Blowfish sidebar layout with DaisyUI cards. The rest of the site (countries, networks, datacenters, laws list) has been redesigned to use the Stitch section-design system with gradient hero, inline stat cards, and full-width content.
+
+**Current state**: `layouts/laws/single.html` delegates entirely to `common-single-page.html` with 7 sidebar card partials.
+
+**Target state**: Inline Stitch template matching `layouts/countries/single.html` pattern — gradient hero, metadata stat cards, full-width content body.
+
+**Reference templates**: `layouts/countries/single.html`, `layouts/countries/bloc.html`
+
+---
+
+## Phase 1: Rewrite single.html to Stitch pattern — DONE
+
+Convert `layouts/laws/single.html` from the `common-single-page.html` partial to an inline Stitch section-design template.
+
+### Tasks
+
+- [x] 1.1 Replace entire `single.html` with inline Stitch template structure
+  - Wrap in `<article class="sd-laws section-design">`
+  - Add gradient hero (`sd-events-hero`) with breadcrumbs, badge ("Legislation"), title, alternate name, and "Official text" external link button
+  - Add metadata stat cards section (`sd-events-stats`) with 3 cards:
+    - **Details**: Year, Type (with emoji), Gov Access, Data Protection, boolean flags
+    - **Applies To**: Jurisdiction countries/blocs with flags and links
+    - **Relevant For**: Audience personas with links
+  - Add main content section (`sd-blog-feed` > `sd-dc-content`) with:
+    - Abstract section
+    - Summary section
+    - Table of contents
+    - Main markdown content
+    - Related Laws section (conflicts, complements, implements, etc.)
+    - Same Jurisdiction laws
+    - Topics and Tags as pill links
+    - Back link to /laws/
+  - Add floating TOC partial
+
+- [x] 1.2 Inline the law type emoji/label logic (from sidebar/laws-details-card.html)
+- [x] 1.3 Inline the jurisdiction resolution logic (from sidebar/laws-appliesto.html)
+- [x] 1.4 Inline the related laws logic (from sidebar/laws-related-card.html)
+
+### Validation
+
+- Hugo build succeeds
+- Page renders with gradient hero, stat cards, full-width content
+- All metadata visible (year, type, access, protection, flags, jurisdictions, audience)
+- Related laws links work
+- External "Official text" link works
+
+---
+
+## Phase 2: CSS additions if needed — DONE (no changes needed)
+
+### Tasks
+
+- [x] 2.1 Check if any law-specific CSS classes are needed beyond existing `.sd-laws` styles — None needed, reuses existing `sd-events-stats`, `sd-events-stat-card`, `sd-filter-pills` etc.
+- [x] 2.2 Add any missing responsive/dark-mode styles for the new layout — Not needed, inherits from shared section-design styles
+
+### Validation
+
+- Dark mode renders correctly
+- Mobile layout is responsive
+- No visual regressions on laws list page
+
+---
+
+## Phase 3: Commit, push, and verify — TODO
+
+### Tasks
+
+- [ ] 3.1 Commit changes on feature branch
+- [ ] 3.2 Push and create PR if needed
+- [ ] 3.3 Verify on live site after CI deploy
+
+### Validation
+
+- Live page matches design intent
+- All interactive elements work
+
+---
+
+## Files to Modify
+
+- `layouts/laws/single.html` — Primary template rewrite
+- `assets/css/custom.css` — CSS additions if needed
+
+## Files for Reference (read-only)
+
+- `layouts/countries/single.html` — Target pattern
+- `layouts/partials/sidebar/laws-details-card.html` — Details metadata logic
+- `layouts/partials/sidebar/laws-appliesto.html` — Jurisdiction logic
+- `layouts/partials/sidebar/laws-related-card.html` — Related laws logic
+- `layouts/partials/sidebar/common-audience-card.html` — Audience logic
+- `content/laws/gdpr/index.md` — Example law frontmatter

--- a/layouts/datacenters/country.html
+++ b/layouts/datacenters/country.html
@@ -30,7 +30,6 @@
   {{ $countryFlag = $country.flag | default "" }}
 {{ end }}
 
-{{/* Auto-generate clean title without flag (partial will add flag) */}}
 {{ $displayTitle := printf "%s Datacenters" $countryName }}
 
 {{/* Build country lookup for use by partials */}}
@@ -61,114 +60,199 @@
 {{ $providerItems = sort $providerItems "name" "asc" }}
 {{ $providerItems = sort $providerItems "count" "desc" }}
 
-<article class="max-w-full">
-  {{/* Detail Header with breadcrumbs */}}
-  {{ partial "common-detail-header.html" (dict
-      "title" $displayTitle
-      "description" .Description
-      "flag" $countryFlag
-      "breadcrumbs" (slice
-          (dict "title" "Datacenters" "url" "/datacenters/")
-      )
-  ) }}
+{{/* Risk level */}}
+{{ $riskLevel := "" }}
+{{ $riskEmoji := "" }}
+{{ with $country }}
+  {{ $riskLevel = .riskLevel | default "" }}
+  {{ if eq $riskLevel "low" }}{{ $riskEmoji = "✅" }}
+  {{ else if eq $riskLevel "moderate" }}{{ $riskEmoji = "⚠️" }}
+  {{ else if eq $riskLevel "elevated" }}{{ $riskEmoji = "🔶" }}
+  {{ else if eq $riskLevel "high" }}{{ $riskEmoji = "🚨" }}
+  {{ else if eq $riskLevel "sanctioned" }}{{ $riskEmoji = "⛔" }}
+  {{ end }}
+{{ end }}
 
-  {{/* Two-column layout */}}
-  <section class="flex flex-col max-w-full mt-0 lg:flex-row">
+{{/* Bloc memberships */}}
+{{ $blocs := slice }}
+{{ range $countries }}
+  {{ if .memberCountryIds }}
+    {{ if in .memberCountryIds $countryId }}
+      {{ $blocs = $blocs | append . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
 
-    {{/* Right Sidebar */}}
-    {{ partial "sidebar/common-sidebar.html" . }}
+<article class="sd-datacenters section-design">
 
-        {{/* Country Details Card */}}
-        {{ partial "sidebar/datacenter-country-details-card.html" (dict "country" $country "providerCount" (len $providerItems) "regionCount" $totalRegions) }}
+  {{/* ============================================================
+       HERO
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/datacenters/" style="color: inherit; text-decoration: none; opacity: 0.7;">Datacenters</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ $countryName }}</span>
+          </span>
+        </nav>
 
-        {{/* Link to full country page for laws */}}
-        <div class="card bg-base-100 shadow-sm border border-base-300">
-          <div class="card-body p-4">
-            <h3 class="card-title text-sm font-semibold flex items-center gap-2">
-              {{ partial "data-icon.html" (dict "name" "scale" "color" "primary" "size" "4") }}
-              Laws & Regulations
-            </h3>
-            <p class="text-sm text-neutral-600 dark:text-neutral-400">
-              View detailed jurisdiction laws and regulations.
-            </p>
-            <a href="/countries/{{ $slug }}/" class="btn btn-sm btn-outline btn-primary mt-2">
-              View {{ $countryName }} Laws
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Datacenter Region</span>
+        </div>
+
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">
+          {{ if $countryFlag }}<span style="margin-right: 0.5rem;">{{ $countryFlag }}</span>{{ end }}{{ $displayTitle }}
+        </h1>
+
+        {{ with .Description }}
+        <p class="sd-events-hero-description">{{ . }}</p>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       METADATA GRID
+       ============================================================ */}}
+  <section class="sd-events-stats">
+    {{/* Region Details card */}}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Region Details</span>
+      <dl style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.8;">
+        {{ if $riskLevel }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Risk Level</dt>
+          <dd style="font-weight: 500;">{{ $riskEmoji }} {{ $riskLevel | title }}</dd>
+        </div>
+        {{ end }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Providers</dt>
+          <dd style="font-weight: 500;">{{ len $providerItems }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">DC Regions</dt>
+          <dd style="font-weight: 500;">{{ $totalRegions }}</dd>
+        </div>
+      </dl>
+    </div>
+
+    {{/* Memberships card */}}
+    {{ if gt (len $blocs) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Bloc Memberships</span>
+      <div style="margin-top: 0.5rem;" class="sd-filter-pills">
+        {{ range $blocs }}
+        <a href="/countries/{{ .slug }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+          {{ with .flag }}{{ . }} {{ end }}{{ .name }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+
+    {{/* Top Providers card */}}
+    {{ if gt (len $providerItems) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Top Providers</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range first 5 $providerItems }}
+        <li style="display: flex; justify-content: space-between; align-items: center;">
+          <a href="/datacenters/{{ .provider.identifier }}/" style="text-decoration: none; color: inherit;">{{ .name }}</a>
+          <span style="opacity: 0.6; font-size: 0.75rem;">{{ .count }} regions</span>
+        </li>
+        {{ end }}
+        {{ if gt (len $providerItems) 5 }}
+        <li style="opacity: 0.5; font-size: 0.75rem;">+ {{ sub (len $providerItems) 5 }} more</li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+  </section>
+
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* Summary */}}
+      {{ with .Params.summary }}
+      <p style="font-size: 1.125rem; color: var(--sd-on-surface-variant); line-height: 1.7; margin-bottom: 1.5rem;">{{ . }}</p>
+      {{ end }}
+
+      {{/* Body */}}
+      {{ with .Params.body }}
+      <p>{{ . }}</p>
+      {{ end }}
+
+      {{ if $countryId }}
+        {{/* Map */}}
+        <h2 id="map">Datacenter Map</h2>
+        <div class="not-prose" style="margin-top: 1rem;">
+          {{ $mapShortcode := printf "{{< datacenter-map countries=\"%s\" showFilters=\"false\" >}}" $countryId }}
+          {{ $mapShortcode | .Page.RenderString }}
+        </div>
+
+        {{/* Providers */}}
+        <h2 id="providers">Datacenter Providers in {{ $countryName }}</h2>
+        {{ partial "datacenter-country-providers-inline.html" (dict "countryId" $countryId "regionsById" $regionsById) }}
+
+        {{/* Regions */}}
+        <h2 id="regions">Locations by City</h2>
+        {{ partial "datacenter-country-regions-inline.html" (dict "countryId" $countryId "regionsById" $regionsById) }}
+
+        {{/* Laws link */}}
+        <div style="margin-top: 2rem; padding: 1rem 1.5rem; border-radius: 0.75rem; background: var(--sd-surface-container-low); border: 1px solid var(--sd-outline-variant);">
+          <span style="font-size: 0.875rem; opacity: 0.7;">Jurisdiction laws and regulations</span>
+          <div style="margin-top: 0.5rem;">
+            <a href="/countries/{{ $slug }}/" style="color: var(--sd-primary); text-decoration: none; font-weight: 500;">
+              View {{ $countryName }} jurisdiction details →
             </a>
           </div>
         </div>
 
-        {{/* Risk Assessment Card */}}
-        {{ partial "sidebar/jurisdiction-risk-card.html" (dict "countryId" $countryId) }}
-
-        {{/* Jurisdiction Memberships Card */}}
-        {{ partial "sidebar/jurisdiction-memberships-card.html" (dict "countryId" $countryId) }}
-
-        {{/* Providers sidebar section */}}
-        {{ partial "datacenter-country-providers-sidebar.html" (dict "providerItems" $providerItems "countryName" $countryName "countryFlag" $countryFlag) }}
-
-        {{/* Table of Contents */}}
-        {{ $showToc := in .TableOfContents "<ul" }}
-        {{ if $showToc }}
-        <div class="mt-6">
-          {{ partial "toc.html" . }}
-        </div>
+        {{/* Custom markdown content */}}
+        {{ if .Content }}
+        <hr style="border-color: var(--sd-outline-variant); margin: 2rem 0;">
+        {{ .Content }}
         {{ end }}
+      {{ end }}
 
-    {{ partial "sidebar/common-sidebar-end.html" . }}
-
-    {{/* Main Content */}}
-    <div class="min-w-0 flex-1">
-      <div class="article-content prose dark:prose-invert max-w-none mb-20">
-
-        {{/* Summary - detailed overview from frontmatter */}}
-        {{ with .Params.summary }}
-        <p class="lead text-lg text-neutral-600 dark:text-neutral-400 mb-6">{{ . }}</p>
-        {{ end }}
-
-        {{/* Body content */}}
-        {{ with .Params.body }}
-        <p class="mb-8">{{ . }}</p>
-        {{ end }}
-
-        {{/* Always auto-generate the standard sections */}}
-        {{ if $countryId }}
-          {{/* Map */}}
-          {{ $mapShortcode := printf "{{< datacenter-map countries=\"%s\" showFilters=\"false\" >}}" $countryId }}
-          {{ $mapShortcode | .Page.RenderString }}
-
-          {{/* Providers */}}
-          <h2 id="providers">Datacenter Providers in {{ $countryName }}</h2>
-          {{ partial "datacenter-country-providers-inline.html" (dict "countryId" $countryId "regionsById" $regionsById) }}
-
-          {{/* Regions - all datacenter locations by city */}}
-          <h2 id="regions">Locations by City</h2>
-          {{ partial "datacenter-country-regions-inline.html" (dict "countryId" $countryId "regionsById" $regionsById) }}
-
-          {{/* Render any custom markdown content */}}
-          {{ if .Content }}
-          <hr class="mt-8">
-          {{ .Content }}
+      {{/* Related content tags */}}
+      {{ with .GetTerms "tags" }}
+      <div style="margin-top: 2rem;">
+        <h3>Tags</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="{{ .RelPermalink }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ .LinkTitle }}</a>
           {{ end }}
-        {{ end }}
-
-        {{/* Back link */}}
-        <hr class="mt-8">
-        <p>
-          <a href="/datacenters/">← Back to all datacenters</a> |
-          <a href="/countries/{{ $slug }}/">View {{ $countryName }} jurisdiction details</a>
-        </p>
+        </div>
       </div>
-    </div>
+      {{ end }}
 
+      {{/* Back link */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/datacenters/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all datacenters</a>
+      </div>
+
+    </div>
   </section>
 
-  {{/* Floating TOC for mobile */}}
-  {{ $tocSections := slice
-      (dict "id" "datacenter-map-chart" "title" "Map" "icon" "🗺️")
-      (dict "id" "providers" "title" "Providers" "icon" "🖥️")
-      (dict "id" "regions" "title" "Locations" "icon" "📍")
-      (dict "id" "sidebar" "title" "Details" "icon" "📋")
-  }}
-  {{ partial "floating-toc.html" (dict "sections" $tocSections) }}
 </article>
+
+{{/* Floating TOC */}}
+{{ $tocSections := slice
+    (dict "id" "map" "title" "Map" "icon" "🗺️")
+    (dict "id" "providers" "title" "Providers" "icon" "🖥️")
+    (dict "id" "regions" "title" "Locations" "icon" "📍")
+}}
+{{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/datacenters/single.html
+++ b/layouts/datacenters/single.html
@@ -58,7 +58,7 @@
 {{ if eq $hqRisk "high" }}{{ $riskEmoji = "🚨" }}{{ end }}
 {{ if eq $hqRisk "sanctioned" }}{{ $riskEmoji = "⛔" }}{{ end }}
 
-{{/* Compute provider physical-country distribution for sidebar */}}
+{{/* Compute provider physical-country distribution */}}
 {{ $countryCounts := dict }}
 {{ $providerRegions := slice }}
 {{ if $provider }}
@@ -116,186 +116,167 @@
   {{ end }}
 {{ end }}
 
-<article class="max-w-full">
-  {{/* Detail Header with breadcrumbs */}}
-  {{ partial "common-detail-header.html" (dict
-      "title" $displayTitle
-      "description" .Description
-      "icon" "server"
-      "breadcrumbs" (slice
-          (dict "title" "Datacenters" "url" "/datacenters/")
-      )
-  ) }}
+<article class="sd-datacenters section-design">
 
-  {{/* Two-column layout */}}
-  <section class="flex flex-col max-w-full mt-0 lg:flex-row">
+  {{/* ============================================================
+       HERO
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/datacenters/" style="color: inherit; text-decoration: none; opacity: 0.7;">Datacenters</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ $providerName }}</span>
+          </span>
+        </nav>
 
-    {{/* Right Sidebar */}}
-    {{ partial "sidebar/common-sidebar.html" . }}
-
-        {{/* External link button */}}
-        {{ with $provider.url }}
-        <a class="btn btn-primary btn-outline w-full gap-2"
-           href="{{ . }}"
-           target="_blank"
-           rel="noopener noreferrer">
-          {{ partial "data-icon.html" (dict "name" "external" "size" "4") }}
-          Visit website
-        </a>
-        {{ end }}
-
-        {{/* Provider Details Card */}}
-        {{ if $provider }}
-        <div class="card bg-base-100 shadow-sm border border-base-300">
-          <div class="card-body p-4">
-            <h3 class="card-title text-sm font-semibold flex items-center gap-2">
-              {{ partial "data-icon.html" (dict "name" "info" "color" "primary" "size" "4") }}
-              Provider Details
-            </h3>
-            <dl class="mt-2 text-sm">
-              {{/* HQ */}}
-              <div class="flex justify-between py-1">
-                <dt class="text-neutral-500 dark:text-neutral-400">Headquarters</dt>
-                <dd class="font-medium">{{ if $hqFlag }}{{ $hqFlag }} {{ end }}{{ $hqName }}</dd>
-              </div>
-              {{/* Total Regions */}}
-              <div class="flex justify-between py-1">
-                <dt class="text-neutral-500 dark:text-neutral-400">Total Regions</dt>
-                <dd class="font-medium">{{ len $providerRegions }}</dd>
-              </div>
-              {{/* Countries */}}
-              <div class="flex justify-between py-1">
-                <dt class="text-neutral-500 dark:text-neutral-400">Countries</dt>
-                <dd class="font-medium">{{ len $countryCounts }}</dd>
-              </div>
-              {{/* Provider Type */}}
-              {{ with $provider.providerType }}
-              <div class="flex justify-between py-1">
-                <dt class="text-neutral-500 dark:text-neutral-400">Type</dt>
-                <dd class="font-medium">{{ . | title }}</dd>
-              </div>
-              {{ end }}
-              {{/* Data updated */}}
-              {{ with $provider.updated }}
-              <div class="pt-2 mt-2 border-t border-base-200">
-                <div class="text-xs text-neutral-500 dark:text-neutral-400">Data updated {{ . }}</div>
-              </div>
-              {{ end }}
-            </dl>
-          </div>
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Provider</span>
         </div>
+
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">
+          {{ $displayTitle }}
+        </h1>
+
+        {{ with .Description }}
+        <p class="sd-events-hero-description">{{ . }}</p>
         {{ end }}
-
-        {{/* Jurisdiction Card */}}
-        {{ if $hqSlug }}
-        <div class="card bg-base-100 shadow-sm border border-base-300">
-          <div class="card-body p-4">
-            <h3 class="card-title text-sm font-semibold flex items-center gap-2">
-              {{ partial "data-icon.html" (dict "name" "scale" "color" "warning" "size" "4") }}
-              Jurisdiction
-            </h3>
-            <div class="mt-2">
-              <a href="/countries/{{ $hqSlug }}/"
-                 class="text-sm block px-2 py-1 -mx-2 rounded hover:bg-base-200 dark:hover:bg-neutral-800 no-underline">
-                {{ if $hqFlag }}{{ $hqFlag }} {{ end }}{{ $hqName }} laws
-              </a>
-              {{ if $riskEmoji }}
-              <div class="mt-2 text-xs text-neutral-500 dark:text-neutral-400">
-                {{ $riskEmoji }} {{ $riskLabel | title }} risk jurisdiction
-              </div>
-              {{ end }}
-            </div>
-          </div>
-        </div>
-        {{ end }}
-
-        {{/* Countries Card */}}
-        {{ if gt (len $countryItems) 0 }}
-        <div class="card bg-base-100 shadow-sm border border-base-300">
-          <div class="card-body p-4">
-            <h3 class="card-title text-sm font-semibold flex items-center gap-2">
-              {{ partial "data-icon.html" (dict "name" "globe" "color" "info" "size" "4") }}
-              Countries
-            </h3>
-            <div class="text-xs text-neutral-500 dark:text-neutral-400 mb-2">
-              {{ len $countryItems }} countries, {{ len $providerRegions }} regions
-            </div>
-            <ul class="space-y-0.5 max-h-48 overflow-y-auto">
-              {{ range $countryItems }}
-              <li>
-                {{ if .slug }}
-                <a href="/countries/{{ .slug }}/"
-                   title="{{ .name }}: {{ .count }} regions"
-                   class="text-sm block px-2 py-1 -mx-2 rounded hover:bg-base-200 dark:hover:bg-neutral-800 no-underline flex justify-between items-center">
-                  <span>{{ if .flag }}{{ .flag }} {{ end }}{{ .name }}</span>
-                  <span class="text-neutral-500 dark:text-neutral-400">{{ .count }}</span>
-                </a>
-                {{ else }}
-                <span class="text-sm block px-2 py-1 -mx-2 flex justify-between items-center">
-                  <span>{{ if .flag }}{{ .flag }} {{ end }}{{ .name }}</span>
-                  <span class="text-neutral-500 dark:text-neutral-400">{{ .count }}</span>
-                </span>
-                {{ end }}
-              </li>
-              {{ end }}
-            </ul>
-          </div>
-        </div>
-        {{ end }}
-
-        {{/* Compare Card */}}
-        {{ if gt (len $compare) 0 }}
-        <div class="card bg-base-100 shadow-sm border border-base-300">
-          <div class="card-body p-4">
-            <h3 class="card-title text-sm font-semibold flex items-center gap-2">
-              {{ partial "data-icon.html" (dict "name" "compare" "color" "secondary" "size" "4") }}
-              Compare
-            </h3>
-            <div class="text-xs text-neutral-500 dark:text-neutral-400 mb-2">
-              Other {{ $ptype }} providers
-            </div>
-            <ul class="space-y-0.5">
-              {{ range first 8 $compare }}
-              <li>
-                <a href="/datacenters/{{ .identifier }}/"
-                   title="{{ .name }}: {{ .regionCount }} regions"
-                   class="text-sm block px-2 py-1 -mx-2 rounded hover:bg-base-200 dark:hover:bg-neutral-800 no-underline flex justify-between items-center">
-                  <span>{{ .name }}</span>
-                  <span class="text-neutral-500 dark:text-neutral-400">{{ .regionCount }}</span>
-                </a>
-              </li>
-              {{ end }}
-            </ul>
-          </div>
-        </div>
-        {{ end }}
-
-        {{/* Related content */}}
-        {{ partial "related-content-sidebar.html" . }}
-
-        {{/* Table of Contents */}}
-        {{ $showToc := in .TableOfContents "<ul" }}
-        {{ if $showToc }}
-        <div class="mt-6">
-          {{ partial "toc.html" . }}
-        </div>
-        {{ end }}
-
-    {{ partial "sidebar/common-sidebar-end.html" . }}
-
-    {{/* Main Content */}}
-    <div class="min-w-0 flex-1">
-      <div class="article-content prose dark:prose-invert max-w-none mb-20">
-        {{ .Content }}
-
-        {{/* Back link */}}
-        <hr class="mt-8">
-        <p>
-          <a href="/datacenters/">← Back to all datacenters</a>
-        </p>
       </div>
     </div>
-
   </section>
+
+  {{/* ============================================================
+       METADATA GRID
+       ============================================================ */}}
+  <section class="sd-events-stats">
+    {{/* Provider Details card */}}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Provider Details</span>
+      <dl style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.8;">
+        {{ if $hqName }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Headquarters</dt>
+          <dd style="font-weight: 500;">{{ if $hqFlag }}{{ $hqFlag }} {{ end }}{{ $hqName }}</dd>
+        </div>
+        {{ end }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Total Regions</dt>
+          <dd style="font-weight: 500;">{{ len $providerRegions }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Countries</dt>
+          <dd style="font-weight: 500;">{{ len $countryCounts }}</dd>
+        </div>
+        {{ with $provider.providerType }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Type</dt>
+          <dd style="font-weight: 500;">{{ . | title }}</dd>
+        </div>
+        {{ end }}
+        {{ if $riskEmoji }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Risk Level</dt>
+          <dd style="font-weight: 500;">{{ $riskEmoji }} {{ $riskLabel | title }}</dd>
+        </div>
+        {{ end }}
+      </dl>
+    </div>
+
+    {{/* Countries card */}}
+    {{ if gt (len $countryItems) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Countries</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range first 5 $countryItems }}
+        <li style="display: flex; justify-content: space-between; align-items: center;">
+          {{ if .slug }}
+          <a href="/countries/{{ .slug }}/" style="text-decoration: none; color: inherit;">{{ if .flag }}{{ .flag }} {{ end }}{{ .name }}</a>
+          {{ else }}
+          <span>{{ if .flag }}{{ .flag }} {{ end }}{{ .name }}</span>
+          {{ end }}
+          <span style="opacity: 0.6; font-size: 0.75rem;">{{ .count }} regions</span>
+        </li>
+        {{ end }}
+        {{ if gt (len $countryItems) 5 }}
+        <li style="opacity: 0.5; font-size: 0.75rem;">+ {{ sub (len $countryItems) 5 }} more</li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+
+    {{/* Compare card */}}
+    {{ if gt (len $compare) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Compare {{ $ptype | title }} Providers</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range first 5 $compare }}
+        <li style="display: flex; justify-content: space-between; align-items: center;">
+          <a href="/datacenters/{{ .identifier }}/" style="text-decoration: none; color: inherit;">{{ .name }}</a>
+          <span style="opacity: 0.6; font-size: 0.75rem;">{{ .regionCount }} regions</span>
+        </li>
+        {{ end }}
+        {{ if gt (len $compare) 5 }}
+        <li style="opacity: 0.5; font-size: 0.75rem;">+ {{ sub (len $compare) 5 }} more</li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+  </section>
+
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* External link button */}}
+      {{ with $provider.url }}
+      <div style="margin-bottom: 2rem;">
+        <a href="{{ . }}" target="_blank" rel="noopener noreferrer"
+           style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.625rem 1.25rem; border: 1px solid var(--sd-primary); color: var(--sd-primary); border-radius: 0.5rem; text-decoration: none; font-size: 0.875rem; font-weight: 500; transition: all 0.2s ease;">
+          <span class="material-symbols-outlined" style="font-size: 1.125rem;">open_in_new</span>
+          Visit website
+        </a>
+      </div>
+      {{ end }}
+
+      {{/* Page content */}}
+      {{ if .Content }}
+      {{ .Content }}
+      {{ end }}
+
+      {{/* Related content tags */}}
+      {{ with .GetTerms "tags" }}
+      <div style="margin-top: 2rem;">
+        <h3>Tags</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="{{ .RelPermalink }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ .LinkTitle }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* Back link */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/datacenters/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all datacenters</a>
+      </div>
+
+    </div>
+  </section>
+
 </article>
+
+{{/* Floating TOC */}}
+{{ $tocSections := slice
+    (dict "id" "content" "title" "Overview" "icon" "📄")
+}}
+{{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/laws/single.html
+++ b/layouts/laws/single.html
@@ -1,23 +1,376 @@
 {{ define "main" }}
 {{ .Scratch.Set "scope" "single" }}
 
-{{ partial "common-single-page.html" (dict
-    "page" .
-    "icon" "scale"
-    "section" "Laws"
-    "sectionUrl" "/laws/"
-    "headerDescription" .Params.alternateName
-    "externalUrl" .Params.sourceUrl
-    "externalLabel" "Official text"
-    "sidebarCards" (slice
-        "sidebar/laws-details-card.html"
-        "sidebar/laws-appliesto.html"
-        "sidebar/common-audience-card.html"
-        "sidebar/common-topics-card.html"
-        "sidebar/common-tags-card.html"
-        "sidebar/laws-related-card.html"
-        "sidebar/common-related-card.html"
-    )
-) }}
+{{/* ── Law metadata ── */}}
+{{ $lawId := .Params.identifier | default "" }}
+{{ $year := .Params.legislationDate | default "" }}
+{{ $alternateName := .Params.alternateName | default "" }}
+{{ $sourceUrl := .Params.sourceUrl | default "" }}
+{{ $category := .Params.category | default "privacy" }}
+{{ $governmentAccess := .Params.governmentAccess | default "none" }}
+{{ $dataProtection := .Params.dataProtection | default "none" }}
+{{ $extraterritorial := .Params.extraterritorial | default false }}
+{{ $requiresLocalization := .Params.requiresLocalization | default false }}
+{{ $requiresBackdoor := .Params.requiresBackdoor | default false }}
+{{ $appliesTo := .Params.legislationJurisdiction | default (slice) }}
+{{ $audienceParams := .Params.audience | default (slice) }}
+{{ $relatedLawsData := .Params.isRelatedTo | default dict }}
 
+{{/* ── Law type styling ── */}}
+{{ $typeEmoji := "" }}
+{{ $typeLabel := $category }}
+{{ if eq $category "privacy" }}{{ $typeEmoji = "🛡️" }}{{ $typeLabel = "Privacy" }}
+{{ else if eq $category "access" }}{{ $typeEmoji = "🔓" }}{{ $typeLabel = "Access" }}
+{{ else if eq $category "surveillance" }}{{ $typeEmoji = "👁️" }}{{ $typeLabel = "Surveillance" }}
+{{ else if eq $category "localization" }}{{ $typeEmoji = "📍" }}{{ $typeLabel = "Localization" }}
+{{ else if eq $category "security" }}{{ $typeEmoji = "🔒" }}{{ $typeLabel = "Security" }}
+{{ else if eq $category "sector" }}{{ $typeEmoji = "📋" }}{{ $typeLabel = "Sector" }}
+{{ end }}
+
+{{/* ── Government access label ── */}}
+{{ $accessLabel := $governmentAccess }}
+{{ if eq $governmentAccess "broad" }}{{ $accessLabel = "Broad" }}
+{{ else if eq $governmentAccess "targeted" }}{{ $accessLabel = "Targeted" }}
+{{ else if eq $governmentAccess "limited" }}{{ $accessLabel = "Limited" }}
+{{ else if eq $governmentAccess "none" }}{{ $accessLabel = "None" }}
+{{ end }}
+
+{{/* ── Data protection label ── */}}
+{{ $protectionLabel := $dataProtection }}
+{{ if eq $dataProtection "strong" }}{{ $protectionLabel = "Strong" }}
+{{ else if eq $dataProtection "moderate" }}{{ $protectionLabel = "Moderate" }}
+{{ else if eq $dataProtection "weak" }}{{ $protectionLabel = "Weak" }}
+{{ else if eq $dataProtection "none" }}{{ $protectionLabel = "None" }}
+{{ end }}
+
+{{/* ── Jurisdiction resolution ── */}}
+{{ $regionsById := dict }}
+{{ $countries := site.Data.countries.countries.itemListElement | default (slice) }}
+{{ range $countries }}
+  {{ $regionsById = merge $regionsById (dict .identifier .) }}
+{{ end }}
+{{ $blocsById := dict }}
+{{ range (site.Data.blocs.blocs.itemListElement | default (slice)) }}
+  {{ $blocsById = merge $blocsById (dict .identifier .) }}
+{{ end }}
+
+{{ $appliesToItems := slice }}
+{{ range $appliesTo }}
+  {{ $id := . }}
+  {{ $name := $id }}
+  {{ $flag := "" }}
+  {{ $slug := "" }}
+  {{ $isBloc := false }}
+  {{ $region := index $regionsById $id }}
+  {{ if $region }}
+    {{ $name = $region.name | default $id }}
+    {{ $flag = $region.flag | default "" }}
+    {{ $slug = $region.slug | default "" }}
+  {{ else }}
+    {{ $bloc := index $blocsById $id }}
+    {{ if $bloc }}
+      {{ $name = $bloc.name | default $id }}
+      {{ $flag = $bloc.flag | default "" }}
+      {{ $slug = $bloc.slug | default $bloc.identifier | default $id }}
+      {{ $isBloc = true }}
+    {{ end }}
+  {{ end }}
+  {{ $appliesToItems = $appliesToItems | append (dict "id" $id "name" $name "flag" $flag "slug" $slug "isBloc" $isBloc) }}
+{{ end }}
+
+{{/* ── Audience resolution ── */}}
+{{ $audienceList := site.Data.audience.audience.itemListElement | default (slice) }}
+
+{{/* ── Related laws lookup ── */}}
+{{ $lawsById := dict }}
+{{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
+  {{ $lawsById = merge $lawsById (dict .identifier .) }}
+{{ end }}
+
+{{/* ── Same jurisdiction laws ── */}}
+{{ $sameJurisdictionLaws := slice }}
+{{ if gt (len $appliesTo) 0 }}
+  {{ range (site.Data.laws.laws.itemListElement | default (slice)) }}
+    {{ $otherLaw := . }}
+    {{ if ne $otherLaw.identifier $lawId }}
+      {{ $found := false }}
+      {{ range $otherLaw.legislationJurisdiction }}
+        {{ $otherId := . }}
+        {{ range $appliesTo }}
+          {{ if eq . $otherId }}{{ $found = true }}{{ end }}
+        {{ end }}
+      {{ end }}
+      {{ if $found }}
+        {{ $sameJurisdictionLaws = $sameJurisdictionLaws | append $otherLaw }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<article class="sd-laws section-design">
+
+  {{/* ============================================================
+       HERO
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        {{/* Breadcrumbs */}}
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/laws/" style="color: inherit; text-decoration: none; opacity: 0.7;">Laws</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ .Title }}</span>
+          </span>
+        </nav>
+
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Legislation</span>
+        </div>
+
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">
+          {{ $typeEmoji }} {{ .Title }}
+        </h1>
+
+        {{ if $alternateName }}
+        <p class="sd-events-hero-description">{{ $alternateName }}</p>
+        {{ else }}
+        {{ with .Description }}
+        <p class="sd-events-hero-description">{{ . }}</p>
+        {{ end }}
+        {{ end }}
+
+        {{ if $sourceUrl }}
+        <div style="margin-top: 1.25rem;">
+          <a href="{{ $sourceUrl }}" target="_blank" rel="noopener noreferrer"
+             style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.5rem 1.25rem; border-radius: 0.5rem; background: rgba(255,255,255,0.15); color: inherit; text-decoration: none; font-size: 0.875rem; font-weight: 500; backdrop-filter: blur(4px); border: 1px solid rgba(255,255,255,0.2); transition: background 0.2s;">
+            Official text ↗
+          </a>
+        </div>
+        {{ end }}
+      </div>
+    </div>
+  </section>
+
+  {{/* ============================================================
+       METADATA CARDS
+       ============================================================ */}}
+  <section class="sd-events-stats">
+
+    {{/* Details card */}}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Details</span>
+      <dl style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.8;">
+        {{ if $year }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Year</dt>
+          <dd style="font-weight: 500;">{{ $year }}</dd>
+        </div>
+        {{ end }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Type</dt>
+          <dd style="font-weight: 500;">{{ $typeEmoji }} {{ $typeLabel }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Gov Access</dt>
+          <dd style="font-weight: 500;">{{ $accessLabel }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Data Protection</dt>
+          <dd style="font-weight: 500;">{{ $protectionLabel }}</dd>
+        </div>
+        {{ if or $extraterritorial $requiresLocalization $requiresBackdoor }}
+        <div style="margin-top: 0.5rem; padding-top: 0.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+          {{ if $extraterritorial }}
+          <div>🌍 Extraterritorial</div>
+          {{ end }}
+          {{ if $requiresLocalization }}
+          <div>📍 Requires Localization</div>
+          {{ end }}
+          {{ if $requiresBackdoor }}
+          <div style="color: var(--sd-error, #ba1a1a);">🔑 Requires Backdoor</div>
+          {{ end }}
+        </div>
+        {{ end }}
+      </dl>
+    </div>
+
+    {{/* Applies To card */}}
+    {{ if gt (len $appliesToItems) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Applies To</span>
+      <div style="margin-top: 0.5rem;" class="sd-filter-pills">
+        {{ range $appliesToItems }}
+        <a href="/countries/{{ .slug }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+          {{ with .flag }}{{ . }} {{ end }}{{ .name }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+
+    {{/* Relevant For card */}}
+    {{ if gt (len $audienceParams) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Relevant For</span>
+      <div style="margin-top: 0.5rem;" class="sd-filter-pills">
+        {{ range $audienceParams }}
+        {{ $audienceId := . }}
+        {{ $audience := dict }}
+        {{ range $audienceList }}
+          {{ if eq .identifier $audienceId }}{{ $audience = . }}{{ end }}
+        {{ end }}
+        {{ $name := $audience.name | default ($audienceId | humanize | title) }}
+        <a href="/personas/{{ $audienceId }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+          {{ $name }}
+        </a>
+        {{ end }}
+      </div>
+    </div>
+    {{ end }}
+
+  </section>
+
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* Abstract */}}
+      {{ with .Params.abstract }}
+      <div style="margin-bottom: 1.5rem;">
+        <h2 id="abstract" style="font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem;">Abstract</h2>
+        <p style="font-size: 1rem; color: var(--sd-on-surface-variant); line-height: 1.7;">{{ . }}</p>
+      </div>
+      {{ end }}
+
+      {{/* Summary */}}
+      {{ with .Params.summary }}
+      <div style="margin-bottom: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <h2 id="summary" style="font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem;">Summary</h2>
+        <p style="font-size: 1.0625rem; color: var(--sd-on-surface-variant); line-height: 1.7;">{{ . }}</p>
+      </div>
+      {{ end }}
+
+      {{/* Main article content */}}
+      {{ if .Content }}
+      <div style="margin-bottom: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <div class="article-content prose dark:prose-invert max-w-none">
+          {{ .Content }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* ── Related Laws ── */}}
+      {{ $hasSemanticRelations := gt (len $relatedLawsData) 0 }}
+      {{ if or $hasSemanticRelations (gt (len $sameJurisdictionLaws) 0) }}
+      <div style="margin-bottom: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <h2 id="related-laws" style="font-size: 1.25rem; font-weight: 600; margin-bottom: 1rem;">Related Laws</h2>
+
+        {{ if $hasSemanticRelations }}
+          {{/* Relationship type template — renders a labeled group of law links */}}
+          {{ $relationTypes := slice
+            (dict "key" "conflicts_with" "label" "Conflicts with" "color" "var(--sd-error, #ba1a1a)")
+            (dict "key" "complements" "label" "Works with" "color" "")
+            (dict "key" "implements" "label" "Implements" "color" "")
+            (dict "key" "implemented_by" "label" "Implemented by" "color" "")
+            (dict "key" "extends" "label" "Extends" "color" "")
+            (dict "key" "extended_by" "label" "Extended by" "color" "")
+            (dict "key" "amends" "label" "Amends" "color" "")
+            (dict "key" "amended_by" "label" "Amended by" "color" "")
+            (dict "key" "succeeds" "label" "Succeeds" "color" "")
+            (dict "key" "succeeded_by" "label" "Succeeded by" "color" "")
+            (dict "key" "interprets" "label" "Interprets" "color" "")
+            (dict "key" "interpreted_by" "label" "Interpreted by" "color" "")
+          }}
+
+          <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr)); gap: 1rem;">
+            {{ range $relationTypes }}
+              {{ $relLabel := .label }}
+              {{ $relColor := .color }}
+              {{ $items := index $relatedLawsData .key }}
+              {{ if $items }}
+              <div>
+                <h3 style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.7; margin-bottom: 0.5rem;{{ if $relColor }} color: {{ $relColor }};{{ end }}">{{ $relLabel }}</h3>
+                <ul style="list-style: none; padding: 0; margin: 0;">
+                  {{ range $items }}
+                  {{ $lawData := index $lawsById .identifier }}
+                  {{ $tooltip := "" }}
+                  {{ with $lawData }}{{ $tooltip = .alternateName | default .name }}{{ end }}
+                  <li style="margin-bottom: 0.25rem;">
+                    <a href="/laws/{{ .identifier }}/" title="{{ $tooltip }}" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">
+                      {{ .name }} <span style="opacity: 0.5;">({{ .legislationDate }})</span>
+                    </a>
+                  </li>
+                  {{ end }}
+                </ul>
+              </div>
+              {{ end }}
+            {{ end }}
+          </div>
+        {{ end }}
+
+        {{/* Same jurisdiction */}}
+        {{ if gt (len $sameJurisdictionLaws) 0 }}
+        <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+          <h3 style="font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.7; margin-bottom: 0.5rem;">Same Jurisdiction</h3>
+          <div class="sd-filter-pills">
+            {{ range first 8 $sameJurisdictionLaws }}
+            <a href="/laws/{{ .identifier }}/" title="{{ .alternateName | default .name }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">
+              {{ .name }} <span style="opacity: 0.5;">({{ .legislationDate }})</span>
+            </a>
+            {{ end }}
+          </div>
+        </div>
+        {{ end }}
+      </div>
+      {{ end }}
+
+      {{/* ── Topics ── */}}
+      {{ with .Params.topics }}
+      <div style="margin-bottom: 1rem;">
+        <h3 style="font-size: 0.875rem; font-weight: 600; opacity: 0.7; margin-bottom: 0.5rem;">Topics</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="/topics/{{ . }}/" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ . | humanize | title }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* ── Tags ── */}}
+      {{ with .GetTerms "tags" }}
+      <div style="margin-bottom: 1.5rem;">
+        <h3 style="font-size: 0.875rem; font-weight: 600; opacity: 0.7; margin-bottom: 0.5rem;">Tags</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="{{ .RelPermalink }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ .LinkTitle }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* Back link */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/laws/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all laws</a>
+      </div>
+
+    </div>
+  </section>
+
+</article>
+
+{{/* Floating TOC */}}
+{{ $tocSections := slice
+    (dict "id" "abstract" "title" "Abstract" "icon" "📄")
+    (dict "id" "summary" "title" "Summary" "icon" "📝")
+    (dict "id" "related-laws" "title" "Related" "icon" "⚖️")
+}}
+{{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}

--- a/layouts/shortcodes/jurisdiction-map.html
+++ b/layouts/shortcodes/jurisdiction-map.html
@@ -116,74 +116,76 @@
 {{ end }}
 
 <div id="jurisdiction-map">
-<div class="not-prose stats stats-vertical sm:stats-horizontal shadow-lg w-full mb-8 bg-base-100">
-  <div class="stat">
-    <div class="stat-figure text-primary">
-      {{ partial "data-icon.html" (dict "name" "globe" "color" "primary" "size" "8") }}
+<section class="not-prose sd-events-stats sd-jurisdiction-map-stats">
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Countries Tracked</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $totalCountries }}</span>
+      <span class="sd-events-stat-desc">Jurisdictions monitored</span>
     </div>
-    <div class="stat-title">Countries Tracked</div>
-    <div class="stat-value text-primary">{{ $totalCountries }}</div>
-    <div class="stat-desc">Jurisdictions monitored</div>
   </div>
-  <div class="stat">
-    <div class="stat-figure text-accent">
-      {{ partial "data-icon.html" (dict "name" "users" "color" "accent" "size" "8") }}
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Regional Blocs</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $totalBlocs }}</span>
+      <span class="sd-events-stat-desc">Trade & legal frameworks</span>
     </div>
-    <div class="stat-title">Regional Blocs</div>
-    <div class="stat-value text-accent">{{ $totalBlocs }}</div>
-    <div class="stat-desc">Trade & legal frameworks</div>
   </div>
-  <div class="stat">
-    <div class="stat-figure text-success">
-      {{ partial "data-icon.html" (dict "name" "check-circle" "color" "success" "size" "8") }}
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Low Risk</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $lowRisk }}</span>
+      <span class="sd-events-stat-desc">Safe jurisdictions</span>
     </div>
-    <div class="stat-title">Low Risk</div>
-    <div class="stat-value text-success">{{ $lowRisk }}</div>
-    <div class="stat-desc">Safe jurisdictions</div>
   </div>
-  <div class="stat">
-    <div class="stat-figure text-error">
-      {{ partial "data-icon.html" (dict "name" "alert-triangle" "color" "error" "size" "8") }}
+  <div class="sd-events-stat-card">
+    <span class="sd-events-stat-label">Elevated+ Risk</span>
+    <div class="sd-events-stat-row">
+      <span class="sd-headline sd-events-stat-value">{{ $elevatedRisk }}</span>
+      <span class="sd-events-stat-desc">Require caution</span>
     </div>
-    <div class="stat-title">Elevated+ Risk</div>
-    <div class="stat-value text-error">{{ $elevatedRisk }}</div>
-    <div class="stat-desc">Require caution</div>
   </div>
-</div>
+</section>
 
 
 {{/* Risk Level Filter */}}
-<div class="not-prose flex flex-wrap items-center gap-2 mb-4">
-  <span class="text-sm font-semibold opacity-70">Risk:</span>
-  <div class="join" id="laws-risk-chips" data-filter-group="risk">
-    <button class="join-item btn btn-sm btn-active" data-filter="risk" data-value="all">All</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="low">✅ Low</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="moderate">⚠️ Moderate</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="elevated">🔶 Elevated</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="high">🚨 High</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="risk" data-value="sanctioned">⛔ Sanctioned</button>
+<div class="not-prose" data-filter-group="risk">
+  <div class="sd-laws-filter-header">
+    <span class="sd-laws-filter-label">Risk:</span>
+    <button class="sd-laws-filter-btn sd-laws-filter-btn--active" data-filter="risk" data-value="all">All</button>
+  </div>
+  <div class="sd-laws-filter-options" id="laws-risk-chips">
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="low">✅ Low</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="moderate">⚠️ Moderate</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="elevated">🔶 Elevated</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="high">🚨 High</button>
+    <button class="sd-laws-filter-btn" data-filter="risk" data-value="sanctioned">⛔ Sanctioned</button>
   </div>
 </div>
 
 {{/* Bloc Filter */}}
-<div class="not-prose flex flex-wrap items-center gap-2 mb-4">
-  <span class="text-sm font-semibold opacity-70">Bloc:</span>
-  <div class="join" id="laws-bloc-chips" data-filter-group="bloc">
-    <button class="join-item btn btn-sm btn-active" data-filter="bloc" data-value="all">All</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="eu">🇪🇺 EU</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="eea">🇪🇺 EEA</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="five-eyes">👁️ Five Eyes</button>
-    <button class="join-item btn btn-sm btn-ghost" data-filter="bloc" data-value="adequacy">✓ Adequacy</button>
+<div class="not-prose" data-filter-group="bloc">
+  <div class="sd-laws-filter-header">
+    <span class="sd-laws-filter-label">Bloc:</span>
+    <button class="sd-laws-filter-btn sd-laws-filter-btn--active" data-filter="bloc" data-value="all">All</button>
+  </div>
+  <div class="sd-laws-filter-options" id="laws-bloc-chips">
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="eu">🇪🇺 EU</button>
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="eea">🇪🇺 EEA</button>
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="five-eyes">👁️ Five Eyes</button>
+    <button class="sd-laws-filter-btn" data-filter="bloc" data-value="adequacy">✓ Adequacy</button>
   </div>
 </div>
 
 {{/* Features Filter */}}
-<div class="not-prose flex flex-wrap items-center gap-2 mb-6">
-  <span class="text-sm font-semibold opacity-70">Features:</span>
-  <div class="flex flex-wrap gap-2" data-filter-group="features">
-    <button class="btn btn-sm btn-ghost gap-1" id="laws-has-dc" data-filter="datacenters" data-value="true">🏢 Has Datacenters</button>
+<div class="not-prose" data-filter-group="features">
+  <div class="sd-laws-filter-header">
+    <span class="sd-laws-filter-label">Features:</span>
   </div>
-  <button id="laws-map-reset" class="btn btn-sm btn-ghost ml-auto">Reset filters</button>
+  <div class="sd-laws-filter-options">
+    <button class="sd-laws-filter-btn" id="laws-has-dc" data-filter="datacenters" data-value="true">🏢 Has Datacenters</button>
+    <button class="sd-laws-filter-btn sd-laws-filter-btn--clear" id="laws-map-reset">Reset filters</button>
+  </div>
 </div>
 
 <div id="jurisdiction-map-chart" class="not-prose" style="width: 100%; height: 520px; background: var(--tw-prose-pre-bg, #f5f5f5); border-radius: 12px;"></div>
@@ -327,14 +329,21 @@
       var blocsById = blocById();
 
       function setActiveButton(groupEl, value) {
-        groupEl.querySelectorAll('button').forEach(function(b) {
-          b.classList.remove('btn-active');
-          b.classList.add('btn-ghost');
+        groupEl.querySelectorAll('button[data-filter]').forEach(function(b) {
+          b.classList.remove('sd-laws-filter-btn--active');
         });
-        var target = groupEl.querySelector('button[data-value="' + value + '"]') || groupEl.querySelector('button[data-value="all"]');
-        if (target) {
-          target.classList.add('btn-active');
-          target.classList.remove('btn-ghost');
+        var container = groupEl.closest('[data-filter-group]');
+        var allBtn = container ? container.querySelector('.sd-laws-filter-header button[data-value="all"]') : null;
+        if (allBtn) allBtn.classList.remove('sd-laws-filter-btn--active');
+        if (value === 'all' && allBtn) {
+          allBtn.classList.add('sd-laws-filter-btn--active');
+        } else {
+          var target = groupEl.querySelector('button[data-value="' + value + '"]');
+          if (target) {
+            target.classList.add('sd-laws-filter-btn--active');
+          } else if (allBtn) {
+            allBtn.classList.add('sd-laws-filter-btn--active');
+          }
         }
       }
 
@@ -365,11 +374,9 @@
           dcBtn.addEventListener('click', function() {
             hasDatacentersOnly = !hasDatacentersOnly;
             if (hasDatacentersOnly) {
-              dcBtn.classList.add('btn-active');
-              dcBtn.classList.remove('btn-ghost');
+              dcBtn.classList.add('sd-laws-filter-btn--active');
             } else {
-              dcBtn.classList.remove('btn-active');
-              dcBtn.classList.add('btn-ghost');
+              dcBtn.classList.remove('sd-laws-filter-btn--active');
             }
             focusedIds = null;
             renderAll();
@@ -383,11 +390,9 @@
         var dcBtn = document.getElementById('laws-has-dc');
         if (dcBtn) {
           if (hasDatacentersOnly) {
-            dcBtn.classList.add('btn-active');
-            dcBtn.classList.remove('btn-ghost');
+            dcBtn.classList.add('sd-laws-filter-btn--active');
           } else {
-            dcBtn.classList.remove('btn-active');
-            dcBtn.classList.add('btn-ghost');
+            dcBtn.classList.remove('sd-laws-filter-btn--active');
           }
         }
       }


### PR DESCRIPTION
## Summary

- Restyle jurisdiction-map stats and filters to Stitch design system
- Redesign law single pages to Stitch section-design system (hero + metadata grid + full-width content)
- Redesign datacenter single/country pages from old sidebar layout to Stitch section-design system (hero + inline metadata grid + full-width content, no sidebar)

## Changes

- `layouts/datacenters/single.html` — Provider detail pages now use Stitch hero, 3-card metadata grid (Provider Details, Countries, Compare), full-width content
- `layouts/datacenters/country.html` — Country datacenter pages now use Stitch hero, 3-card metadata grid (Region Details, Memberships, Top Providers), full-width content with map/providers/regions
- `layouts/laws/single.html` — Law pages redesigned to Stitch pattern
- Jurisdiction map stats/filters restyled to Stitch design tokens

## Test plan

- [ ] Verify datacenter provider pages render correctly (e.g. `/datacenters/azure/`)
- [ ] Verify datacenter country pages render correctly (e.g. `/datacenters/germany/`)
- [ ] Verify law single pages render correctly
- [ ] Verify jurisdiction map stats/filters styling
- [ ] Check dark mode rendering on all pages
- [ ] Verify floating TOC navigation works
- [ ] Verify map shortcodes render on country pages