### PR TITLE
Redesign datacenter provider pages to Stitch design system

### DIFF
--- a/layouts/datacenters/provider.html
+++ b/layouts/datacenters/provider.html
@@ -50,113 +50,242 @@
   {{ end }}
 {{ end }}
 
+{{/* Risk label + emoji */}}
+{{ $riskLevels := (site.Data.blocs.riskLevels | default dict) }}
+{{ $riskLabel := $vendorRisk }}
+{{ with index $riskLevels $vendorRisk }}
+  {{ if .label }}{{ $riskLabel = .label }}{{ end }}
+{{ end }}
+{{ $riskEmoji := "" }}
+{{ if eq $vendorRisk "low" }}{{ $riskEmoji = "✅" }}{{ end }}
+{{ if eq $vendorRisk "moderate" }}{{ $riskEmoji = "⚠️" }}{{ end }}
+{{ if eq $vendorRisk "elevated" }}{{ $riskEmoji = "🔶" }}{{ end }}
+{{ if eq $vendorRisk "high" }}{{ $riskEmoji = "🚨" }}{{ end }}
+{{ if eq $vendorRisk "sanctioned" }}{{ $riskEmoji = "⛔" }}{{ end }}
+
+{{/* Compute provider physical-country distribution */}}
+{{ $countryCounts := dict }}
+{{ range $regions }}
+  {{ $cid := .countryId | default "" }}
+  {{ if $cid }}
+    {{ $prev := index $countryCounts $cid | default 0 }}
+    {{ $countryCounts = merge $countryCounts (dict $cid (add $prev 1)) }}
+  {{ end }}
+{{ end }}
+
+{{ $countryItems := slice }}
+{{ range $cid, $count := $countryCounts }}
+  {{ $meta := index $countriesById $cid }}
+  {{ $name := $cid }}
+  {{ $flag := "" }}
+  {{ $slug := "" }}
+  {{ if $meta }}
+    {{ $name = $meta.name | default $cid }}
+    {{ $flag = $meta.flag | default "" }}
+    {{ $slug = $meta.slug | default "" }}
+  {{ end }}
+  {{ $countryItems = $countryItems | append (dict "id" $cid "count" $count "meta" $meta "name" $name "flag" $flag "slug" $slug) }}
+{{ end }}
+{{ $countryItems = sort $countryItems "count" "desc" }}
+
+{{/* Compare list (same type) */}}
+{{ $allProviders := site.Data.datacenters.datacenters | default (slice) }}
+{{ $compare := slice }}
+{{ if $providerType }}
+  {{ $same := where $allProviders "providerType" $providerType }}
+  {{ range $same }}
+    {{ if ne .identifier $providerId }}
+      {{ $regionCount := len (.regions | default (slice)) }}
+      {{ $compare = $compare | append (dict "identifier" .identifier "name" .name "regionCount" $regionCount) }}
+    {{ end }}
+  {{ end }}
+  {{ $compare = sort $compare "regionCount" "desc" }}
+{{ end }}
+
 {{/* Auto-generate title */}}
 {{ $displayTitle := .Title }}
 {{ if or (not .Title) (eq .Title "Index") (eq .Title "") }}
   {{ $displayTitle = printf "%s Datacenters" $providerName }}
 {{ end }}
 
-<article class="max-w-full">
-  {{/* Detail Header with breadcrumbs */}}
-  {{ partial "common-detail-header.html" (dict
-      "title" $displayTitle
-      "description" .Description
-      "icon" "server"
-      "breadcrumbs" (slice
-          (dict "title" "Datacenters" "url" "/datacenters/")
-      )
-  ) }}
+<article class="sd-datacenters section-design">
 
-  {{/* Two-column layout */}}
-  <section class="flex flex-col max-w-full mt-0 lg:flex-row">
+  {{/* ============================================================
+       HERO
+       ============================================================ */}}
+  <section class="sd-events-hero" style="padding-bottom: 3rem;">
+    <div class="sd-events-hero-bg"></div>
+    <div class="sd-events-hero-content">
+      <div style="max-width: 48rem;">
+        <nav style="margin-bottom: 1rem;">
+          <span style="font-size: 0.875rem; opacity: 0.8;">
+            <a href="/" style="color: inherit; text-decoration: none; opacity: 0.7;">Home</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <a href="/datacenters/" style="color: inherit; text-decoration: none; opacity: 0.7;">Datacenters</a>
+            <span style="margin: 0 0.25rem;">›</span>
+            <span>{{ $providerName }}</span>
+          </span>
+        </nav>
 
-    {{/* Right Sidebar */}}
-    {{ partial "sidebar/common-sidebar.html" . }}
-
-        {{/* External link button */}}
-        {{ with $providerUrl }}
-        <a class="btn btn-primary btn-outline w-full gap-2"
-           href="{{ . }}"
-           target="_blank"
-           rel="noopener noreferrer">
-          {{ partial "data-icon.html" (dict "name" "external" "size" "4") }}
-          Visit website
-        </a>
-        {{ end }}
-
-        {{/* Provider Details Card */}}
-        {{ partial "sidebar/datacenter-provider-details-card.html" (dict "provider" $provider "vendorCountry" $vendorCountry) }}
-
-        {{/* Risk Assessment Card */}}
-        {{ partial "sidebar/jurisdiction-risk-card.html" (dict "countryId" $vendorCountryId) }}
-
-        {{/* Jurisdiction Memberships Card */}}
-        {{ partial "sidebar/jurisdiction-memberships-card.html" (dict "countryId" $vendorCountryId) }}
-
-        {{/* Laws by Type Card */}}
-        {{ partial "sidebar/jurisdiction-laws-card.html" (dict "countryId" $vendorCountryId) }}
-
-        {{/* Countries Card */}}
-        {{ partial "sidebar/datacenter-provider-countries-card.html" (dict "provider" $provider "regionsById" $countriesById) }}
-
-        {{/* Compare Card */}}
-        {{ $allProviders := site.Data.datacenters.datacenters | default (slice) }}
-        {{ partial "sidebar/datacenter-provider-compare-card.html" (dict "provider" $provider "allProviders" $allProviders) }}
-
-        {{/* Related content */}}
-        {{ partial "related-content-sidebar.html" . }}
-
-        {{/* Table of Contents */}}
-        {{ $showToc := in .TableOfContents "<ul" }}
-        {{ if $showToc }}
-        <div class="mt-6">
-          {{ partial "toc.html" . }}
-        </div>
-        {{ end }}
-
-    {{ partial "sidebar/common-sidebar-end.html" . }}
-
-    {{/* Main Content */}}
-    <div class="min-w-0 flex-1">
-      <div class="article-content prose dark:prose-invert max-w-none mb-20">
-
-        {{/* Map */}}
-        <div id="map">
-        {{ $mapShortcode := printf "{{< datacenter-map providers=\"%s\" showFilters=\"false\" >}}" $providerId }}
-        {{ $mapShortcode | .Page.RenderString }}
+        <div class="sd-events-hero-badge">
+          <span class="sd-events-hero-badge-dot"></span>
+          <span>Provider</span>
         </div>
 
-        {{/* Locations */}}
-        <h2 id="locations">Locations by Country</h2>
-        {{ partial "datacenter-provider-locations-inline.html" (dict "provider" $provider "regionsById" $countriesById) }}
+        <h1 class="sd-headline sd-events-hero-title" style="font-size: clamp(1.75rem, 4vw, 2.5rem);">
+          {{ $displayTitle }}
+        </h1>
 
-        {{/* Laws */}}
-        <h2 id="laws">Laws in provider jurisdiction</h2>
-        {{ partial "datacenter-provider-laws-inline.html" (dict "vendorCountryId" $vendorCountryId "vendorCountry" $vendorCountry) }}
-
-        {{/* Render any custom markdown content */}}
-        {{ if .Content }}
-        <hr class="mt-8">
-        {{ .Content }}
+        {{ with .Description }}
+        <p class="sd-events-hero-description">{{ . }}</p>
         {{ end }}
-
-        {{/* Back link */}}
-        <hr class="mt-8">
-        <p>
-          <a href="/datacenters/">← Back to all providers</a>
-        </p>
       </div>
     </div>
-
   </section>
 
-  {{/* Floating TOC for mobile */}}
-  {{ $tocSections := slice
-      (dict "id" "map" "title" "Map" "icon" "🗺️")
-      (dict "id" "locations" "title" "Locations" "icon" "📍")
-      (dict "id" "laws" "title" "Laws" "icon" "⚖️")
-      (dict "id" "sidebar" "title" "Details" "icon" "📋")
-  }}
-  {{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+  {{/* ============================================================
+       METADATA GRID
+       ============================================================ */}}
+  <section class="sd-events-stats">
+    {{/* Provider Details card */}}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Provider Details</span>
+      <dl style="margin-top: 0.5rem; font-size: 0.875rem; line-height: 1.8;">
+        {{ if $vendorCountryName }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Headquarters</dt>
+          <dd style="font-weight: 500;">{{ if $vendorCountryFlag }}{{ $vendorCountryFlag }} {{ end }}{{ $vendorCountryName }}</dd>
+        </div>
+        {{ end }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Total Regions</dt>
+          <dd style="font-weight: 500;">{{ len $regions }}</dd>
+        </div>
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Countries</dt>
+          <dd style="font-weight: 500;">{{ len $countryCounts }}</dd>
+        </div>
+        {{ with $providerType }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Type</dt>
+          <dd style="font-weight: 500;">{{ . | title }}</dd>
+        </div>
+        {{ end }}
+        {{ if $riskEmoji }}
+        <div style="display: flex; justify-content: space-between;">
+          <dt style="opacity: 0.6;">Risk Level</dt>
+          <dd style="font-weight: 500;">{{ $riskEmoji }} {{ $riskLabel | title }}</dd>
+        </div>
+        {{ end }}
+      </dl>
+    </div>
+
+    {{/* Countries card */}}
+    {{ if gt (len $countryItems) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Countries</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range first 5 $countryItems }}
+        <li style="display: flex; justify-content: space-between; align-items: center;">
+          {{ if .slug }}
+          <a href="/countries/{{ .slug }}/" style="text-decoration: none; color: inherit;">{{ if .flag }}{{ .flag }} {{ end }}{{ .name }}</a>
+          {{ else }}
+          <span>{{ if .flag }}{{ .flag }} {{ end }}{{ .name }}</span>
+          {{ end }}
+          <span style="opacity: 0.6; font-size: 0.75rem;">{{ .count }} regions</span>
+        </li>
+        {{ end }}
+        {{ if gt (len $countryItems) 5 }}
+        <li style="opacity: 0.5; font-size: 0.75rem;">+ {{ sub (len $countryItems) 5 }} more</li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+
+    {{/* Compare card */}}
+    {{ if gt (len $compare) 0 }}
+    <div class="sd-events-stat-card" style="text-align: left;">
+      <span class="sd-events-stat-label">Compare {{ $providerType | title }} Providers</span>
+      <ul style="margin-top: 0.5rem; list-style: none; padding: 0; font-size: 0.875rem; line-height: 2;">
+        {{ range first 5 $compare }}
+        <li style="display: flex; justify-content: space-between; align-items: center;">
+          <a href="/datacenters/{{ .identifier }}/" style="text-decoration: none; color: inherit;">{{ .name }}</a>
+          <span style="opacity: 0.6; font-size: 0.75rem;">{{ .regionCount }} regions</span>
+        </li>
+        {{ end }}
+        {{ if gt (len $compare) 5 }}
+        <li style="opacity: 0.5; font-size: 0.75rem;">+ {{ sub (len $compare) 5 }} more</li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
+  </section>
+
+  {{/* ============================================================
+       MAIN CONTENT
+       ============================================================ */}}
+  <section class="sd-blog-feed">
+    <div class="sd-dc-content">
+
+      {{/* External link button */}}
+      {{ with $providerUrl }}
+      <div style="margin-bottom: 2rem;">
+        <a href="{{ . }}" target="_blank" rel="noopener noreferrer"
+           style="display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.625rem 1.25rem; border: 1px solid var(--sd-primary); color: var(--sd-primary); border-radius: 0.5rem; text-decoration: none; font-size: 0.875rem; font-weight: 500; transition: all 0.2s ease;">
+          <span class="material-symbols-outlined" style="font-size: 1.125rem;">open_in_new</span>
+          Visit website
+        </a>
+      </div>
+      {{ end }}
+
+      {{/* Map */}}
+      <div id="map">
+      {{ $mapShortcode := printf "{{< datacenter-map providers=\"%s\" showFilters=\"false\" >}}" $providerId }}
+      {{ $mapShortcode | .Page.RenderString }}
+      </div>
+
+      {{/* Locations */}}
+      <h2 id="locations">Locations by Country</h2>
+      {{ partial "datacenter-provider-locations-inline.html" (dict "provider" $provider "regionsById" $countriesById) }}
+
+      {{/* Laws */}}
+      <h2 id="laws">Laws in provider jurisdiction</h2>
+      {{ partial "datacenter-provider-laws-inline.html" (dict "vendorCountryId" $vendorCountryId "vendorCountry" $vendorCountry) }}
+
+      {{/* Render any custom markdown content */}}
+      {{ if .Content }}
+      <hr style="margin-top: 2rem; border-color: var(--sd-outline-variant, #e5e7eb);">
+      {{ .Content }}
+      {{ end }}
+
+      {{/* Related content tags */}}
+      {{ with .GetTerms "tags" }}
+      <div style="margin-top: 2rem;">
+        <h3>Tags</h3>
+        <div class="sd-filter-pills">
+          {{ range . }}
+          <a href="{{ .RelPermalink }}" class="sd-filter-pill" style="text-decoration: none; font-size: 0.8125rem; padding: 0.375rem 0.875rem;">{{ .LinkTitle }}</a>
+          {{ end }}
+        </div>
+      </div>
+      {{ end }}
+
+      {{/* Back link */}}
+      <div style="margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--sd-outline-variant, #e5e7eb);">
+        <a href="/datacenters/" style="font-size: 0.875rem; color: var(--sd-primary); text-decoration: none;">← Back to all datacenters</a>
+      </div>
+
+    </div>
+  </section>
+
 </article>
+
+{{/* Floating TOC */}}
+{{ $tocSections := slice
+    (dict "id" "map" "title" "Map" "icon" "🗺️")
+    (dict "id" "locations" "title" "Locations" "icon" "📍")
+    (dict "id" "laws" "title" "Laws" "icon" "⚖️")
+}}
+{{ partial "floating-toc.html" (dict "sections" $tocSections) }}
+{{ partial "sovereignsky-footer.html" . }}
 {{ end }}


### PR DESCRIPTION
## Summary
- Redesigns `layouts/datacenters/provider.html` from old sidebar layout to Stitch section-design system
- Adds gradient hero with breadcrumbs, badge, and title
- Replaces sidebar cards with 3 metadata stat cards (Provider Details, Countries, Compare)
- Keeps map, locations by country, and laws sections in full-width content area
- Adds Stitch footer and floating TOC

## Test plan
- [ ] Verify https://sovereignsky.no/datacenters/aws/ renders with new Stitch design
- [ ] Check other provider pages (azure, gcp, hetzner) for consistent rendering
- [ ] Verify map, locations, and laws sections still render correctly
- [ ] Test mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)