### PR TITLE
Redesign homepage partials with Stitch design system

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -4239,3 +4239,153 @@ details[open] .details-marker {
     grid-template-columns: repeat(5, 1fr);
   }
 }
+
+/* Tool card preview (video/image) */
+
+.sd-home-tool-preview {
+  width: 100%;
+  height: 160px;
+  overflow: hidden;
+  border-radius: 0.75rem 0.75rem 0 0;
+  background-color: var(--sd-surface-container-high);
+}
+
+.sd-home-tool-preview video,
+.sd-home-tool-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: top;
+}
+
+.sd-home-tool-card {
+  flex-direction: column;
+}
+
+.sd-home-tool-card .sd-home-tool-preview + .sd-home-tool-content {
+  padding-top: 1rem;
+}
+
+.sd-home-tool-subtitle {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--sd-on-surface);
+  margin: 0 0 0.25rem;
+}
+
+.sd-home-coming-card-link {
+  text-decoration: none;
+  color: inherit;
+  transition: all 0.2s ease;
+}
+
+.sd-home-coming-card-link:hover {
+  border-color: var(--sd-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 88, 190, 0.08);
+}
+
+/* Coming soon sub-items */
+
+.sd-home-coming-subitems {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.sd-home-coming-subitem {
+  padding: 1rem;
+  background-color: var(--sd-surface-container-low);
+  border-radius: 0.75rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+a.sd-home-coming-subitem:hover {
+  background-color: var(--sd-surface-container);
+}
+
+.sd-home-coming-subitem-title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--sd-on-surface);
+  margin: 0 0 0.25rem;
+}
+
+.sd-home-coming-subitem-desc {
+  font-size: 0.8125rem;
+  color: var(--sd-on-surface-variant);
+  margin: 0;
+}
+
+/* Content grid 2-column variant */
+
+.sd-home-content-grid-2 {
+  grid-template-columns: 1fr;
+}
+
+/* Laws grid */
+
+.sd-home-laws-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+.sd-home-laws-group {
+  margin-bottom: 2rem;
+}
+
+.sd-home-laws-group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--sd-outline-variant);
+}
+
+.sd-home-laws-group-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--sd-on-surface);
+  margin: 0;
+}
+
+.sd-home-laws-group-count {
+  font-size: 0.75rem;
+  color: var(--sd-on-surface-variant);
+}
+
+@media (min-width: 768px) {
+  .sd-home-laws-grid-2 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .sd-home-laws-grid-3 {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .sd-home-laws-grid-4 {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .sd-home-content-grid-2 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .sd-home-coming-subitems {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .sd-home-tools-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .sd-home-tools-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/layouts/partials/home/json-driven.html
+++ b/layouts/partials/home/json-driven.html
@@ -19,6 +19,8 @@
     - custom
 */}}
 
+<article class="sd-home section-design">
+
 {{ $sections := site.Data.homepage.sections.itemListElement }}
 
 {{/* Sort sections by weight */}}
@@ -71,3 +73,5 @@
     {{ end }}
   {{ end }}
 {{ end }}
+
+</article>

--- a/layouts/partials/homepage/content-cards.html
+++ b/layouts/partials/homepage/content-cards.html
@@ -1,131 +1,69 @@
 {{/*
-  content-cards.html - Grid of content cards from Hugo pages
-
-  Config options:
-    title: Section title
-    description: Section description
-    background: DaisyUI background color name
-    source: Content source configuration
-    cardStyle: "vertical" (image on top) | "compact" (horizontal)
-    columns: Number of columns (1-4)
-    showMoreLink: Link to full list page
-    showMoreText: Text for show more link
+  content-cards.html - Stitch design content cards from Hugo pages
 */}}
 
 {{ $config := .config }}
 {{ $id := .identifier | default "content" }}
-
-{{ $title := $config.title }}
-{{ $description := $config.description }}
 {{ $background := $config.background | default "" }}
-{{ $cardStyle := $config.cardStyle | default "compact" }}
 {{ $columns := $config.columns | default 3 | int }}
 {{ $footer := $config.footer }}
 
-{{/* Resolve items from source */}}
 {{ $items := partial "homepage/resolve-source.html" $config.source }}
 
-{{/* Build grid columns class */}}
-{{ $gridCols := "lg:grid-cols-3" }}
-{{ if eq $columns 2 }}{{ $gridCols = "lg:grid-cols-2" }}{{ end }}
-{{ if eq $columns 4 }}{{ $gridCols = "lg:grid-cols-4" }}{{ end }}
-
-{{/* Section wrapper */}}
-<section id="{{ $id }}" class="py-16 {{ with $background }}bg-{{ . }}{{ end }} -mx-6 sm:-mx-14 md:-mx-24 lg:-mx-32">
-  <div class="max-w-6xl mx-auto px-6 sm:px-14 md:px-24 lg:px-32">
-
-    {{/* Section header */}}
-    {{ if or $title $description }}
-    <div class="text-center mb-12">
-      {{ with $title }}
-      <h2 class="text-3xl sm:text-4xl font-bold mb-4">{{ . }}</h2>
-      {{ end }}
-      {{ with $description }}
-      <p class="text-lg opacity-80 max-w-2xl mx-auto">{{ . }}</p>
-      {{ end }}
+<section id="{{ $id }}" class="sd-home-section {{ if $background }}sd-home-section-alt{{ end }}">
+  <div class="sd-home-section-inner">
+    {{ if or $config.title $config.description }}
+    <div class="sd-home-section-header">
+      {{ with $config.title }}<h2 class="sd-headline sd-home-section-title">{{ . }}</h2>{{ end }}
+      {{ with $config.description }}<p class="sd-home-section-desc">{{ . }}</p>{{ end }}
     </div>
     {{ end }}
 
-    {{/* Content grid */}}
-    <div class="grid grid-cols-1 sm:grid-cols-2 {{ $gridCols }} gap-4">
+    <div class="sd-home-content-grid {{ if eq $columns 2 }}sd-home-content-grid-2{{ end }}">
       {{ range $items }}
+        {{ $thumbnail := .Resources.GetMatch "{feature*,thumbnail*,cover*}" }}
         {{ $section := .Section }}
 
-        {{/* Get content type info */}}
-        {{ $icon := "document" }}
-        {{ $iconColor := "#6366f1" }}
-        {{ range site.Data.content_types.content_types.itemListElement }}
-          {{ if eq .identifier $section }}
-            {{ $icon = .icon }}
-            {{ $iconColor = .color }}
-          {{ end }}
-        {{ end }}
-
-        {{/* Use page params for icon if available */}}
-        {{ with .Params.icon }}{{ $icon = . }}{{ end }}
-
-        {{/* Get thumbnail */}}
-        {{ $thumbnail := .Resources.GetMatch "{feature*,thumbnail*,cover*}" }}
-
-        {{/* Choose card partial based on cardStyle */}}
-        {{ if eq $cardStyle "vertical" }}
-          {{/* Vertical card: image on top, text below */}}
-          {{ partial "card-vertical.html" (dict
-              "title" .Title
-              "url" .RelPermalink
-              "thumbnail" $thumbnail
-              "date" .Date
-              "summary" (.Summary | plainify | truncate 100)
-              "icon" $icon
-              "iconColor" $iconColor
-          ) }}
-        {{ else }}
-          {{/* Compact card: horizontal layout */}}
-          {{ $category := "" }}
-          {{ $subcategory := "" }}
-          {{ if eq $section "publications" }}
-            {{ with .Params.publication_type }}
-              {{ if eq . "book" }}{{ $category = "Book" }}
-              {{ else if eq . "report" }}{{ $category = "Report" }}
-              {{ else if eq . "paper" }}{{ $category = "Paper" }}
-              {{ else if eq . "guide" }}{{ $category = "Guide" }}
-              {{ else }}{{ $category = . | humanize | title }}{{ end }}
+        <a href="{{ .RelPermalink }}" class="sd-blog-card-inner">
+          <div class="sd-blog-card-image">
+            {{ if $thumbnail }}
+            {{ $img := $thumbnail.Fill "600x340 webp" }}
+            <img src="{{ $img.RelPermalink }}" alt="{{ .Title }}" loading="lazy" />
+            {{ else }}
+            <div class="sd-blog-featured-placeholder">
+              <span class="material-symbols-outlined" style="font-size: 3rem; color: var(--sd-primary); opacity: 0.3;">
+                {{- if eq $section "blog" }}article{{ else if eq $section "publications" }}menu_book{{ else }}description{{ end -}}
+              </span>
+            </div>
             {{ end }}
-            {{ with .Params.publisher }}{{ $subcategory = . }}{{ else }}{{ with .Params.institutions }}{{ $subcategory = index . 0 }}{{ end }}{{ end }}
-          {{ else if eq $section "blog" }}
-            {{ $category = "Blog" }}
-            {{ $subcategory = .Date.Format "Jan 2, 2006" }}
-          {{ else }}
-            {{ $category = $section | humanize | title }}
-          {{ end }}
-
-          {{ partial "card-compact.html" (dict
-              "title" .Title
-              "url" .RelPermalink
-              "category" $category
-              "subcategory" $subcategory
-              "thumbnail" $thumbnail
-              "year" .Params.year
-              "icon" $icon
-          ) }}
-        {{ end }}
+          </div>
+          <div class="sd-blog-card-content">
+            <div class="sd-blog-meta">
+              {{ if eq $section "blog" }}
+              <span>{{ .Date.Format "Jan 2, 2006" }}</span>
+              <span>•</span>
+              <span>{{ .ReadingTime }} min read</span>
+              {{ else if eq $section "publications" }}
+              <span>{{ .Params.publisher | default "Publication" }}</span>
+              {{ with .Params.year }}<span>•</span><span>{{ . }}</span>{{ end }}
+              {{ end }}
+            </div>
+            <h3 class="sd-headline sd-blog-card-title">{{ .Title }}</h3>
+            <p class="sd-blog-card-desc">{{ .Description | default .Summary | plainify | truncate 100 }}</p>
+          </div>
+        </a>
       {{ end }}
     </div>
 
-    {{/* Footer */}}
     {{ with $footer }}
-    <div class="text-center mt-8">
-      {{ with .text }}
-      <p class="text-base-content/70 mb-4">{{ . }}</p>
-      {{ end }}
+    <div class="sd-home-section-cta">
       {{ with .button }}
-      <a href="{{ .url }}" class="btn btn-outline btn-primary">
+      <a href="{{ .url }}" class="sd-home-btn">
         {{ .text }}
-        {{ partial "data-icon.html" (dict "name" "arrow-right" "size" "4" "class" "ml-2") }}
+        <span class="material-symbols-outlined" style="font-size: 1rem;">arrow_forward</span>
       </a>
       {{ end }}
     </div>
     {{ end }}
-
   </div>
 </section>

--- a/layouts/partials/homepage/cta.html
+++ b/layouts/partials/homepage/cta.html
@@ -1,108 +1,65 @@
 {{/*
-  cta.html - Call-to-action banner section
-
-  Config options:
-    style: "gradient" | "solid" | "outline" | "banner"
-    gradient: CSS gradient value (when style is "gradient")
-    title: Headline
-    description: Supporting text
-    features: Array of { icon, text } items
-    buttons: Array of button configs
-    button: Single button config (alternative to buttons)
+  cta.html - Stitch design call-to-action section
 */}}
 
 {{ $config := .config }}
 {{ $id := .identifier | default "cta" }}
-
-{{ $style := $config.style | default "gradient" }}
-{{ $gradient := $config.gradient | default "linear-gradient(135deg, #3b82f6 0%, #8b5cf6 100%)" }}
 {{ $title := $config.title }}
 {{ $description := $config.description }}
 {{ $features := $config.features | default slice }}
 {{ $buttons := $config.buttons | default slice }}
 
-{{/* Support single button config */}}
 {{ with $config.button }}
   {{ $buttons = slice . }}
 {{ end }}
 
-{{/* Build background style */}}
-{{ $bgStyle := "" }}
-{{ $textClass := "text-white" }}
-{{ if eq $style "gradient" }}
-  {{ $bgStyle = printf "background: %s;" $gradient }}
-{{ else if eq $style "solid" }}
-  {{ $bgStyle = "background: var(--fallback-p,oklch(var(--p)));" }}
-{{ else }}
-  {{ $textClass = "" }}
-{{ end }}
+<section id="{{ $id }}" class="sd-home-cta">
+  <div class="sd-home-cta-bg"></div>
+  <div class="sd-home-cta-content">
+    {{ with $title }}
+    <h2 class="sd-headline sd-home-cta-title">{{ . }}</h2>
+    {{ end }}
 
-{{/* CTA section */}}
-<section id="{{ $id }}" class="py-16 -mx-6 sm:-mx-14 md:-mx-24 lg:-mx-32 {{ $textClass }}" style="{{ $bgStyle | safeCSS }}">
-  <div class="max-w-6xl mx-auto px-6 sm:px-14 md:px-24 lg:px-32">
-    <div class="text-center">
+    {{ with $description }}
+    <p class="sd-home-cta-desc">{{ . }}</p>
+    {{ end }}
 
-      {{/* Title */}}
-      {{ with $title }}
-      <h2 class="text-3xl sm:text-4xl font-bold mb-4">{{ . }}</h2>
-      {{ end }}
-
-      {{/* Description */}}
-      {{ with $description }}
-      <p class="text-lg opacity-90 max-w-2xl mx-auto mb-8">{{ . }}</p>
-      {{ end }}
-
-      {{/* Features list */}}
-      {{ if $features }}
-      <div class="flex flex-wrap justify-center gap-6 mb-8">
-        {{ range $features }}
-        <div class="flex items-center gap-2 opacity-90">
-          {{ with .icon }}
-          {{ partial "data-icon.html" (dict "name" . "size" "5") }}
-          {{ end }}
-          <span>{{ .text }}</span>
-        </div>
+    {{ if $features }}
+    <div class="sd-home-cta-actions-grid">
+      {{ range $features }}
+      <div class="sd-home-cta-action">
+        {{ with .icon }}
+        <span class="material-symbols-outlined">
+          {{- if eq . "chart" }}query_stats
+          {{- else if eq . "lightbulb" }}lightbulb
+          {{- else if eq . "megaphone" }}share
+          {{- else if eq . "chat" }}forum
+          {{- else }}{{ . }}
+          {{- end -}}
+        </span>
         {{ end }}
+        <span>{{ .text }}</span>
       </div>
       {{ end }}
-
-      {{/* Buttons */}}
-      {{ if $buttons }}
-      <div class="flex flex-wrap justify-center gap-4">
-        {{ range $buttons }}
-          {{ $btnStyle := .style | default "primary" }}
-          {{ $btnClass := "btn" }}
-
-          {{ if eq $btnStyle "primary" }}
-            {{ if eq $style "gradient" }}
-              {{ $btnClass = "btn btn-white" }}
-            {{ else }}
-              {{ $btnClass = "btn btn-primary" }}
-            {{ end }}
-          {{ else if eq $btnStyle "secondary" }}
-            {{ $btnClass = "btn btn-secondary" }}
-          {{ else if eq $btnStyle "outline" }}
-            {{ if eq $style "gradient" }}
-              {{ $btnClass = "btn btn-outline border-white text-white hover:bg-white hover:text-primary" }}
-            {{ else }}
-              {{ $btnClass = "btn btn-outline btn-primary" }}
-            {{ end }}
-          {{ else if eq $btnStyle "ghost" }}
-            {{ $btnClass = "btn btn-ghost" }}
-          {{ end }}
-
-          <a href="{{ .url }}"
-             class="{{ $btnClass }} btn-lg"
-             {{ if .external }}target="_blank" rel="noopener"{{ end }}>
-            {{ with .icon }}
-            {{ partial "data-icon.html" (dict "name" . "size" "5" "class" "mr-2") }}
-            {{ end }}
-            {{ .text }}
-          </a>
-        {{ end }}
-      </div>
-      {{ end }}
-
     </div>
+    {{ end }}
+
+    {{ if $buttons }}
+    <div class="sd-home-cta-buttons">
+      {{ range $buttons }}
+        {{ $btnClass := "sd-home-btn sd-home-btn-white" }}
+        {{ if eq (.style | default "primary") "outline" }}
+          {{ $btnClass = "sd-home-btn sd-home-btn-outline" }}
+        {{ end }}
+
+        <a href="{{ .url }}" class="{{ $btnClass }}" {{ if .external }}target="_blank" rel="noopener"{{ end }}>
+          {{ with .icon }}
+            {{ if eq . "github" }}{{ partial "data-icon.html" "github" }}{{ end }}
+          {{ end }}
+          {{ .text }}
+        </a>
+      {{ end }}
+    </div>
+    {{ end }}
   </div>
 </section>

--- a/layouts/partials/homepage/hero.html
+++ b/layouts/partials/homepage/hero.html
@@ -1,81 +1,39 @@
 {{/*
-  hero.html - Hero section with gradient/image background
+  hero.html - Stitch design hero section
 
   Config options:
-    style: "gradient" | "image" | "split" | "minimal"
-    gradient: CSS gradient value (when style is "gradient")
-    image: Background image path (when style is "image")
-    imagePosition: "left" | "right" | "center" | "background"
     badge: { text, subtext }
     title: Main headline
-    subtitle: Secondary headline
     description: Supporting text
-    cta: { text, url, style }
 */}}
 
 {{ $config := .config }}
 {{ $id := .identifier | default "hero" }}
 
-{{ $style := $config.style | default "gradient" }}
-{{ $gradient := $config.gradient | default "linear-gradient(135deg, #3b82f6 0%, #06b6d4 50%, #10b981 100%)" }}
-{{ $image := $config.image }}
 {{ $badge := $config.badge }}
 {{ $title := $config.title | default "Welcome" }}
-{{ $subtitle := $config.subtitle }}
 {{ $description := $config.description }}
-{{ $cta := $config.cta }}
 
-{{/* Build background style */}}
-{{ $bgStyle := "" }}
-{{ if eq $style "gradient" }}
-  {{ $bgStyle = printf "background: %s;" $gradient }}
-{{ else if eq $style "image" }}
-  {{ with $image }}
-    {{ $bgStyle = printf "background: url('%s') center/cover no-repeat;" . }}
-  {{ end }}
-{{ end }}
+<section id="{{ $id }}" class="sd-events-hero sd-home-hero">
+  <div class="sd-events-hero-bg"></div>
+  <div class="sd-events-hero-content">
+    <div style="max-width: 48rem;">
+      {{ with $badge }}
+      <div class="sd-events-hero-badge">
+        <span class="sd-events-hero-badge-dot"></span>
+        <span>{{ .text }}</span>
+        {{ with .subtext }}
+        <span style="opacity: 0.6;">·</span>
+        <span>{{ . }}</span>
+        {{ end }}
+      </div>
+      {{ end }}
 
-{{/* Hero section - break out of body padding */}}
-<div id="{{ $id }}" class="relative overflow-hidden -mx-6 sm:-mx-14 md:-mx-24 lg:-mx-32" style="{{ $bgStyle | safeCSS }}">
-  <div class="max-w-6xl mx-auto px-6 sm:px-14 md:px-24 lg:px-32 py-20 sm:py-28 text-center text-white">
-    {{/* Badge */}}
-    {{ with $badge }}
-    <div class="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-2 text-sm font-semibold mb-6">
-      <span>{{ .text }}</span>
-      {{ with .subtext }}
-      <span class="opacity-60">·</span>
-      <span class="opacity-80">{{ . }}</span>
+      <h1 class="sd-headline sd-events-hero-title">{{ $title }}</h1>
+
+      {{ with $description }}
+      <p class="sd-events-hero-description">{{ . }}</p>
       {{ end }}
     </div>
-    {{ end }}
-
-    {{/* Title */}}
-    <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight mb-6">
-      {{ $title }}
-    </h1>
-
-    {{/* Subtitle */}}
-    {{ with $subtitle }}
-    <h2 class="text-2xl sm:text-3xl font-semibold opacity-90 mb-4">
-      {{ . }}
-    </h2>
-    {{ end }}
-
-    {{/* Description */}}
-    {{ with $description }}
-    <p class="text-lg sm:text-xl opacity-90 max-w-2xl mx-auto">
-      {{ . }}
-    </p>
-    {{ end }}
-
-    {{/* CTA Button */}}
-    {{ with $cta }}
-    <div class="mt-8">
-      <a href="{{ .url }}" class="btn {{ if eq .style "primary" }}btn-primary{{ else if eq .style "secondary" }}btn-secondary{{ else }}btn-outline btn-white{{ end }} btn-lg">
-        {{ with .icon }}{{ partial "data-icon.html" (dict "name" . "size" "5" "class" "mr-2") }}{{ end }}
-        {{ .text }}
-      </a>
-    </div>
-    {{ end }}
   </div>
-</div>
+</section>

--- a/layouts/partials/homepage/laws-list.html
+++ b/layouts/partials/homepage/laws-list.html
@@ -1,32 +1,17 @@
 {{/*
-  laws-list.html - Display selected laws with jurisdiction-style cards
-
-  Config options:
-    title: Section title
-    description: Section description
-    background: DaisyUI background color name
-    identifiers: Array of law identifiers to display
-    groupByType: Whether to group by law type (default: true)
-    columns: Number of columns (default: 2)
-    showMoreLink: Link to full laws page
-    showMoreText: Text for show more link
+  laws-list.html - Stitch design laws list
 */}}
 
 {{ $config := .config }}
 {{ $id := .identifier | default "laws" }}
-
-{{ $title := $config.title }}
-{{ $description := $config.description }}
 {{ $background := $config.background | default "" }}
 {{ $identifiers := $config.identifiers | default slice }}
 {{ $groupByType := $config.groupByType | default true }}
 {{ $columns := $config.columns | default 2 | int }}
 {{ $footer := $config.footer }}
 
-{{/* Get all laws data */}}
 {{ $allLaws := site.Data.laws.laws.itemListElement | default slice }}
 
-{{/* Filter to selected laws, maintaining order */}}
 {{ $selectedLaws := slice }}
 {{ range $identifiers }}
   {{ $targetId := . }}
@@ -37,7 +22,6 @@
   {{ end }}
 {{ end }}
 
-{{/* Get law type vocabulary */}}
 {{ $lawTypesData := site.Data.laws.law_types.itemListElement | default slice }}
 {{ $lawTypes := dict }}
 {{ $typeOrder := slice }}
@@ -50,7 +34,6 @@
   {{ $typeEmojis = merge $typeEmojis (dict .identifier .emoji) }}
 {{ end }}
 
-{{/* Group by type if requested */}}
 {{ $byType := dict }}
 {{ if $groupByType }}
   {{ range $selectedLaws }}
@@ -60,7 +43,6 @@
   {{ end }}
 {{ end }}
 
-{{/* Build region and bloc lookup maps */}}
 {{ $regions := dict }}
 {{ range site.Data.countries.countries.itemListElement }}
   {{ $regions = merge $regions (dict .identifier .) }}
@@ -70,46 +52,33 @@
   {{ $blocs = merge $blocs (dict .identifier .) }}
 {{ end }}
 
-{{/* Build grid class */}}
-{{ $gridCols := "sm:grid-cols-2" }}
-{{ if eq $columns 3 }}{{ $gridCols = "sm:grid-cols-2 lg:grid-cols-3" }}{{ end }}
-{{ if eq $columns 4 }}{{ $gridCols = "sm:grid-cols-2 lg:grid-cols-4" }}{{ end }}
+{{ $gridCols := "sd-home-laws-grid-2" }}
+{{ if eq $columns 3 }}{{ $gridCols = "sd-home-laws-grid-3" }}{{ end }}
+{{ if eq $columns 4 }}{{ $gridCols = "sd-home-laws-grid-4" }}{{ end }}
 
-{{/* Section wrapper */}}
-<section id="{{ $id }}" class="py-16 {{ with $background }}bg-{{ . }}{{ end }} -mx-6 sm:-mx-14 md:-mx-24 lg:-mx-32">
-  <div class="max-w-6xl mx-auto px-6 sm:px-14 md:px-24 lg:px-32">
-
-    {{/* Section header */}}
-    {{ if or $title $description }}
-    <div class="text-center mb-12">
-      {{ with $title }}
-      <h2 class="text-3xl sm:text-4xl font-bold mb-4">{{ . }}</h2>
-      {{ end }}
-      {{ with $description }}
-      <p class="text-lg opacity-80 max-w-2xl mx-auto">{{ . }}</p>
-      {{ end }}
+<section id="{{ $id }}" class="sd-home-section {{ if $background }}sd-home-section-alt{{ end }}">
+  <div class="sd-home-section-inner">
+    {{ if or $config.title $config.description }}
+    <div class="sd-home-section-header">
+      {{ with $config.title }}<h2 class="sd-headline sd-home-section-title">{{ . }}</h2>{{ end }}
+      {{ with $config.description }}<p class="sd-home-section-desc">{{ . }}</p>{{ end }}
     </div>
     {{ end }}
 
-    {{/* Laws display */}}
     {{ if gt (len $selectedLaws) 0 }}
     <div class="not-prose">
       {{ if $groupByType }}
-        {{/* Grouped by type */}}
         {{ range $typeOrder }}
           {{ $type := . }}
           {{ $lawsOfType := index $byType $type }}
           {{ if $lawsOfType }}
-          <div class="mb-8" id="{{ $type }}-laws">
-            {{/* Section header - compact */}}
-            <div class="flex items-center gap-2 mb-3 pb-2 border-b border-base-200">
-              <span class="text-xl">{{ index $typeEmojis $type }}</span>
-              <h3 class="text-base font-semibold text-base-content m-0">{{ index $typeLabels $type }}</h3>
-              <span class="text-xs text-neutral-500">({{ len $lawsOfType }})</span>
+          <div class="sd-home-laws-group">
+            <div class="sd-home-laws-group-header">
+              <span>{{ index $typeEmojis $type }}</span>
+              <h3 class="sd-home-laws-group-title">{{ index $typeLabels $type }}</h3>
+              <span class="sd-home-laws-group-count">({{ len $lawsOfType }})</span>
             </div>
-
-            {{/* Law cards */}}
-            <div class="grid gap-4 {{ $gridCols }}">
+            <div class="sd-home-laws-grid {{ $gridCols }}">
               {{ range $lawsOfType }}
                 {{ partial "law-card.html" (dict "law" . "regions" $regions "blocs" $blocs "lawTypes" $lawTypes) }}
               {{ end }}
@@ -118,35 +87,25 @@
           {{ end }}
         {{ end }}
       {{ else }}
-        {{/* Flat list */}}
-        <div class="grid gap-4 {{ $gridCols }}">
+        <div class="sd-home-laws-grid {{ $gridCols }}">
           {{ range $selectedLaws }}
             {{ partial "law-card.html" (dict "law" . "regions" $regions "blocs" $blocs "lawTypes" $lawTypes) }}
           {{ end }}
         </div>
       {{ end }}
     </div>
-    {{ else }}
-    <div class="alert">
-      {{ partial "data-icon.html" (dict "name" "info" "size" "6" "class" "shrink-0") }}
-      <span>No laws selected.</span>
-    </div>
     {{ end }}
 
-    {{/* Footer */}}
     {{ with $footer }}
-    <div class="text-center mt-8">
-      {{ with .text }}
-      <p class="text-base-content/70 mb-4">{{ . }}</p>
-      {{ end }}
+    <div class="sd-home-section-cta">
+      {{ with .text }}<p style="font-size: 0.875rem; color: var(--sd-on-surface-variant); margin-bottom: 1rem;">{{ . }}</p>{{ end }}
       {{ with .button }}
-      <a href="{{ .url }}" class="btn btn-outline btn-primary">
+      <a href="{{ .url }}" class="sd-home-btn">
         {{ .text }}
-        {{ partial "data-icon.html" (dict "name" "arrow-right" "size" "4" "class" "ml-2") }}
+        <span class="material-symbols-outlined" style="font-size: 1rem;">arrow_forward</span>
       </a>
       {{ end }}
     </div>
     {{ end }}
-
   </div>
 </section>

--- a/layouts/partials/homepage/product-cards.html
+++ b/layouts/partials/homepage/product-cards.html
@@ -1,43 +1,43 @@
-{{/* product-cards.html - Featured product cards with video/image previews */}}
+{{/* product-cards.html - Stitch design product cards */}}
 {{ $config := .config }}
 {{ $identifier := .identifier }}
-{{ $bg := $config.background | default "" }}
 
-<section id="{{ $identifier }}" class="py-16 {{ with $bg }}bg-{{ . }}{{ end }} -mx-6 sm:-mx-14 md:-mx-24 lg:-mx-32">
-  <div class="max-w-6xl mx-auto px-6 sm:px-14 md:px-24 lg:px-32">
-    <div class="text-center mb-12">
-      <h2 class="text-3xl sm:text-4xl font-bold mb-4">{{ $config.title }}</h2>
-      <p class="text-lg opacity-80 max-w-2xl mx-auto">{{ $config.description }}</p>
+<section id="{{ $identifier }}" class="sd-home-section">
+  <div class="sd-home-section-inner">
+    <div class="sd-home-section-header">
+      <h2 class="sd-headline sd-home-section-title">{{ $config.title }}</h2>
+      <p class="sd-home-section-desc">{{ $config.description }}</p>
     </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-{{ len $config.items }} gap-6">
-      {{ range $config.items }}
-      <a href="{{ .url }}" {{ if hasPrefix .url "http" }}target="_blank" rel="noopener"{{ end }} class="card bg-base-100 shadow-lg hover:shadow-xl transition-all duration-300 hover:-translate-y-1 border-2 border-primary/20 overflow-hidden">
-        {{ with .video }}
-        <figure class="h-40 overflow-hidden bg-slate-800">
-          <video autoplay loop muted playsinline class="w-full h-full object-cover object-top">
+    <div class="sd-home-tools-grid">
+      {{ range $i, $item := $config.items }}
+      {{ $colorVar := "primary" }}
+      {{ if eq (mod $i 3) 1 }}{{ $colorVar = "secondary" }}{{ end }}
+      {{ if eq (mod $i 3) 2 }}{{ $colorVar = "tertiary" }}{{ end }}
+
+      <a href="{{ $item.url }}" {{ if hasPrefix $item.url "http" }}target="_blank" rel="noopener"{{ end }} class="sd-home-tool-card">
+        {{ with $item.video }}
+        <div class="sd-home-tool-preview">
+          <video autoplay loop muted playsinline>
             <source src="{{ . }}" type="video/webm" />
           </video>
-        </figure>
-        {{ else }}
-          {{ with .image }}
-          <figure class="h-40 overflow-hidden bg-slate-800">
-            <img src="{{ . }}" alt="" class="w-full h-full object-cover object-top" loading="lazy" />
-          </figure>
-          {{ end }}
-        {{ end }}
-        <div class="card-body">
-          <div class="flex items-center gap-3 mb-2">
-            <div>
-              <h3 class="card-title text-lg">{{ .title }}</h3>
-              <div class="badge badge-primary badge-sm">{{ .badge }}</div>
-            </div>
+        </div>
+        {{ else }}{{ with $item.image }}
+        <div class="sd-home-tool-preview">
+          <img src="{{ . }}" alt="" loading="lazy" />
+        </div>
+        {{ end }}{{ end }}
+        <div class="sd-home-tool-content">
+          <div class="sd-home-tool-header">
+            <h3 class="sd-headline sd-home-tool-title">{{ $item.title }}</h3>
+            <span class="sd-home-tool-badge sd-home-tool-badge-{{ $colorVar }}">{{ $item.badge }}</span>
           </div>
-          {{ with .subtitle }}<p class="font-semibold text-base mb-2">{{ . }}</p>{{ end }}
-          <p class="opacity-70 text-sm">{{ .description }}</p>
-          <div class="card-actions justify-end mt-4">
-            <span class="text-primary font-medium text-sm">{{ .cta }} →</span>
-          </div>
+          {{ with $item.subtitle }}<p class="sd-home-tool-subtitle">{{ . }}</p>{{ end }}
+          <p class="sd-home-tool-desc">{{ $item.description }}</p>
+          <span class="sd-home-tool-link">
+            {{ $item.cta }}
+            <span class="material-symbols-outlined" style="font-size: 0.875rem;">arrow_forward</span>
+          </span>
         </div>
       </a>
       {{ end }}

--- a/layouts/partials/homepage/projects-roadmap.html
+++ b/layouts/partials/homepage/projects-roadmap.html
@@ -1,176 +1,114 @@
 {{/*
-  projects-roadmap.html - Project roadmap display with progress bars
-
-  Config options:
-    title: Section title
-    description: Section description
-    background: DaisyUI background color name
-    items: Array of project items with:
-      - projectRef: Reference to project identifier in data/sovereignsky/projects.json (optional)
-        When projectRef is set, pulls title, description, url from the referenced project.
-        Any fields you specify override the project data.
-      - title: Project name (or override project name)
-      - url: Link to project page (optional - makes title clickable)
-      - description: Project description (or override)
-      - badge: Status badge text
-      - badgeStyle: "primary" | "secondary" | "accent" | "neutral"
-      - progress: Progress percentage (0-100)
-      - progressLabel: Label for progress bar
-      - fullWidth: Whether to span full width
-      - subItems: Array of sub-projects, each can have:
-        - projectRef: Reference to project identifier (optional)
-        - title, description, url (or overrides if projectRef is set)
-    footer: { text, button }
+  projects-roadmap.html - Stitch design project roadmap
 */}}
 
 {{ $config := .config }}
 {{ $id := .identifier | default "projects" }}
-
-{{ $title := $config.title }}
-{{ $description := $config.description }}
 {{ $background := $config.background | default "" }}
 {{ $items := $config.items | default slice }}
 {{ $footer := $config.footer }}
 
-{{/* Section wrapper */}}
-<section id="{{ $id }}" class="py-16 {{ with $background }}bg-{{ . }}{{ end }} -mx-6 sm:-mx-14 md:-mx-24 lg:-mx-32">
-  <div class="max-w-6xl mx-auto px-6 sm:px-14 md:px-24 lg:px-32">
-
-    {{/* Section header */}}
-    {{ if or $title $description }}
-    <div class="text-center mb-12">
-      {{ with $title }}
-      <h2 class="text-3xl sm:text-4xl font-bold mb-4">{{ . }}</h2>
-      {{ end }}
-      {{ with $description }}
-      <p class="text-lg opacity-80 max-w-2xl mx-auto">{{ . }}</p>
-      {{ end }}
+<section id="{{ $id }}" class="sd-home-section {{ if $background }}sd-home-section-alt{{ end }}">
+  <div class="sd-home-section-inner">
+    {{ if or $config.title $config.description }}
+    <div class="sd-home-section-header">
+      {{ with $config.title }}<h2 class="sd-headline sd-home-section-title">{{ . }}</h2>{{ end }}
+      {{ with $config.description }}<p class="sd-home-section-desc">{{ . }}</p>{{ end }}
     </div>
     {{ end }}
 
-    {{/* Projects grid */}}
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div class="sd-home-coming-grid">
       {{ range $items }}
-        {{/* Resolve project reference if present */}}
         {{ $item := . }}
         {{ with .projectRef }}
           {{ $project := partial "homepage/resolve-project.html" . }}
           {{ if $project }}
-            {{/* Map project fields to roadmap fields, with overrides from item */}}
             {{ $title := $item.title | default $project.name }}
             {{ $description := $item.description | default $project.abstract }}
             {{ $url := $item.url | default $project.url }}
-            {{/* Convert external URLs to internal paths if they're on sovereignsky.no */}}
             {{ if hasPrefix $url "https://sovereignsky.no" }}
               {{ $url = strings.TrimPrefix "https://sovereignsky.no" $url }}
             {{ end }}
-            {{/* Merge all fields */}}
             {{ $item = merge $item (dict "title" $title "description" $description "url" $url) }}
           {{ end }}
         {{ end }}
 
-        {{ $fullWidth := $item.fullWidth | default false }}
         {{ $badgeStyle := $item.badgeStyle | default "primary" }}
         {{ $hasSubItems := $item.subItems }}
         {{ $isClickable := and $item.url (not $hasSubItems) }}
 
-        {{/* Card wrapper - clickable if URL and no subItems */}}
         {{ if $isClickable }}
-        <a href="{{ $item.url }}" class="card bg-base-100 shadow-md hover:shadow-xl transition-all duration-300 hover:-translate-y-1 {{ if $fullWidth }}lg:col-span-2{{ end }}">
+        <a href="{{ $item.url }}" class="sd-home-coming-card sd-home-coming-card-link {{ if $item.fullWidth }}sd-home-coming-card-wide{{ end }}">
         {{ else }}
-        <div class="card bg-base-100 shadow-md {{ if $fullWidth }}lg:col-span-2{{ end }}">
+        <div class="sd-home-coming-card {{ if $item.fullWidth }}sd-home-coming-card-wide{{ end }}">
         {{ end }}
-          <div class="card-body">
 
-            {{/* Header with badge */}}
-            <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
-              <h3 class="card-title text-xl">{{ $item.title }}</h3>
-              {{ with $item.badge }}
-              <span class="badge badge-{{ $badgeStyle }}">{{ . }}</span>
-              {{ end }}
+          <span class="sd-home-coming-badge sd-home-coming-badge-{{ $badgeStyle }}">{{ $item.badge }}</span>
+          <h3 class="sd-headline sd-home-coming-title">{{ $item.title }}</h3>
+
+          {{ with $item.description }}
+          <p class="sd-home-coming-desc">{{ . }}</p>
+          {{ end }}
+
+          {{ with $item.progress }}
+          <div class="sd-home-coming-progress">
+            <div class="sd-home-coming-progress-header">
+              <span>Progress</span>
+              <span>{{ with $item.progressLabel }}{{ . }}{{ else }}{{ . }}%{{ end }}</span>
             </div>
-
-            {{/* Description */}}
-            {{ with $item.description }}
-            <p class="opacity-80 mb-4">{{ . }}</p>
-            {{ end }}
-
-            {{/* Progress bar */}}
-            {{ with $item.progress }}
-            <div class="mb-4">
-              <div class="flex justify-between text-sm mb-1">
-                <span class="opacity-70">Progress</span>
-                <span class="font-medium">{{ . }}%</span>
-              </div>
-              <progress class="progress progress-primary w-full" value="{{ . }}" max="100"></progress>
-              {{ with $item.progressLabel }}
-              <div class="text-xs opacity-60 mt-1">{{ . }}</div>
-              {{ end }}
+            <div class="sd-home-coming-progress-bar">
+              <div class="sd-home-coming-progress-fill {{ if eq $badgeStyle "secondary" }}sd-home-coming-progress-fill-secondary{{ end }}" style="width: {{ . }}%;"></div>
             </div>
-            {{ end }}
+          </div>
+          {{ end }}
 
-            {{/* Sub-items */}}
-            {{ with $item.subItems }}
-            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mt-4">
-              {{ range . }}
-                {{/* Resolve project reference for subItem if present */}}
-                {{ $subItem := . }}
-                {{ with .projectRef }}
-                  {{ $project := partial "homepage/resolve-project.html" . }}
-                  {{ if $project }}
-                    {{/* Map project fields to subItem fields, with overrides */}}
-                    {{ $title := $subItem.title | default $project.name }}
-                    {{ $description := $subItem.description | default $project.abstract }}
-                    {{ $url := $subItem.url | default $project.url }}
-                    {{/* Convert external URLs to internal paths if they're on sovereignsky.no */}}
-                    {{ if hasPrefix $url "https://sovereignsky.no" }}
-                      {{ $url = strings.TrimPrefix "https://sovereignsky.no" $url }}
-                    {{ end }}
-                    {{/* Merge all fields */}}
-                    {{ $subItem = merge $subItem (dict "title" $title "description" $description "url" $url) }}
+          {{ with $item.subItems }}
+          <div class="sd-home-coming-subitems">
+            {{ range . }}
+              {{ $subItem := . }}
+              {{ with .projectRef }}
+                {{ $project := partial "homepage/resolve-project.html" . }}
+                {{ if $project }}
+                  {{ $title := $subItem.title | default $project.name }}
+                  {{ $description := $subItem.description | default $project.abstract }}
+                  {{ $url := $subItem.url | default $project.url }}
+                  {{ if hasPrefix $url "https://sovereignsky.no" }}
+                    {{ $url = strings.TrimPrefix "https://sovereignsky.no" $url }}
                   {{ end }}
+                  {{ $subItem = merge $subItem (dict "title" $title "description" $description "url" $url) }}
                 {{ end }}
+              {{ end }}
 
-              {{/* SubItem card - clickable if URL */}}
               {{ if $subItem.url }}
-              <a href="{{ $subItem.url }}" class="bg-base-200 rounded-lg p-4 block hover:bg-base-300 transition-colors">
-                <h4 class="font-semibold mb-1">{{ $subItem.title }}</h4>
-                <p class="text-sm opacity-70">{{ $subItem.description }}</p>
+              <a href="{{ $subItem.url }}" class="sd-home-coming-subitem">
+                <h4 class="sd-home-coming-subitem-title">{{ $subItem.title }}</h4>
+                <p class="sd-home-coming-subitem-desc">{{ $subItem.description }}</p>
               </a>
               {{ else }}
-              <div class="bg-base-200 rounded-lg p-4">
-                <h4 class="font-semibold mb-1">{{ $subItem.title }}</h4>
-                <p class="text-sm opacity-70">{{ $subItem.description }}</p>
+              <div class="sd-home-coming-subitem">
+                <h4 class="sd-home-coming-subitem-title">{{ $subItem.title }}</h4>
+                <p class="sd-home-coming-subitem-desc">{{ $subItem.description }}</p>
               </div>
               {{ end }}
-              {{ end }}
-            </div>
             {{ end }}
-
           </div>
-        {{/* Close card wrapper - </a> or </div> */}}
+          {{ end }}
+
         {{ if $isClickable }}</a>{{ else }}</div>{{ end }}
       {{ end }}
     </div>
 
-    {{/* Footer */}}
     {{ with $footer }}
-    <div class="text-center mt-8">
-      {{ with .text }}
-      <p class="opacity-80 mb-4">{{ . }}</p>
-      {{ end }}
+    <div class="sd-home-section-cta">
+      {{ with .text }}<p style="font-size: 0.875rem; color: var(--sd-on-surface-variant); margin-bottom: 1rem;">{{ . }}</p>{{ end }}
       {{ with .button }}
-      <a href="{{ .url }}"
-         class="btn btn-outline btn-primary"
-         {{ if .external }}target="_blank" rel="noopener"{{ end }}>
-        {{ with .icon }}
-        {{ partial "data-icon.html" (dict "name" . "size" "5" "class" "mr-2") }}
-        {{ end }}
+      <a href="{{ .url }}" class="sd-home-btn" {{ if .external }}target="_blank" rel="noopener"{{ end }}>
+        {{ with .icon }}{{ partial "data-icon.html" (dict "name" . "size" "5" "class" "mr-2") }}{{ end }}
         {{ .text }}
+        <span class="material-symbols-outlined" style="font-size: 1rem;">arrow_forward</span>
       </a>
       {{ end }}
     </div>
     {{ end }}
-
   </div>
 </section>

--- a/layouts/partials/homepage/stats-grid.html
+++ b/layouts/partials/homepage/stats-grid.html
@@ -1,55 +1,22 @@
 {{/*
-  stats-grid.html - Grid of stats cards with icons and counts
-
-  Config options:
-    title: Section title
-    description: Section description
-    background: DaisyUI background color name
-    columns: Number of columns (1-6)
-    items: Array of stat items with:
-      - id: Unique identifier
-      - label: Display label
-      - sublabel: Secondary label
-      - url: Link URL
-      - icon: Icon name
-      - color: Hex color code
-      - countSource: Data path to count items from
-      - value: Static value (alternative to countSource)
+  stats-grid.html - Stitch design stats grid
 */}}
 
 {{ $config := .config }}
 {{ $id := .identifier | default "stats" }}
-
-{{ $title := $config.title }}
-{{ $description := $config.description }}
-{{ $background := $config.background | default "" }}
-{{ $columns := $config.columns | default 4 }}
 {{ $items := $config.items | default slice }}
+{{ $background := $config.background | default "" }}
 
-{{/* Build grid columns class */}}
-{{ $gridCols := "lg:grid-cols-4" }}
-{{ if eq $columns 3 }}{{ $gridCols = "lg:grid-cols-3" }}{{ end }}
-{{ if eq $columns 5 }}{{ $gridCols = "lg:grid-cols-5" }}{{ end }}
-{{ if eq $columns 6 }}{{ $gridCols = "lg:grid-cols-6" }}{{ end }}
-
-{{/* Section wrapper with background */}}
-<section id="{{ $id }}" class="py-16 {{ with $background }}bg-{{ . }}{{ end }} -mx-6 sm:-mx-14 md:-mx-24 lg:-mx-32">
-  <div class="max-w-6xl mx-auto px-6 sm:px-14 md:px-24 lg:px-32">
-
-    {{/* Section header */}}
-    {{ if or $title $description }}
-    <div class="text-center mb-12">
-      {{ with $title }}
-      <h2 class="text-3xl sm:text-4xl font-bold mb-4">{{ . }}</h2>
-      {{ end }}
-      {{ with $description }}
-      <p class="text-lg opacity-80 max-w-2xl mx-auto">{{ . }}</p>
-      {{ end }}
+<section id="{{ $id }}" class="sd-home-section {{ if $background }}sd-home-section-alt{{ end }}">
+  <div class="sd-home-section-inner">
+    {{ if or $config.title $config.description }}
+    <div class="sd-home-section-header">
+      {{ with $config.title }}<h2 class="sd-headline sd-home-section-title">{{ . }}</h2>{{ end }}
+      {{ with $config.description }}<p class="sd-home-section-desc">{{ . }}</p>{{ end }}
     </div>
     {{ end }}
 
-    {{/* Stats grid */}}
-    <div class="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 {{ $gridCols }} gap-4 sm:gap-6">
+    <div class="sd-home-data-grid">
       {{ range $items }}
         {{ $count := 0 }}
         {{ if .countSource }}
@@ -60,25 +27,25 @@
 
         {{ $color := .color | default "#6366f1" }}
 
-        <a href="{{ .url }}" class="card bg-base-100 shadow-md hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
-          <div class="card-body p-5 text-center">
-            {{/* Icon */}}
-            <div class="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-2" style="background: color-mix(in srgb, {{ $color }} 15%, transparent);">
-              {{ partial "data-icon.html" (dict "name" .icon "size" "6" "class" (printf "text-[%s]" $color)) }}
-            </div>
-
-            {{/* Number */}}
-            <div class="text-4xl font-bold leading-none mb-2" style="color: {{ $color }};">{{ $count }}</div>
-
-            {{/* Title and sublabel */}}
-            <div class="font-semibold text-base leading-tight">{{ .label }}</div>
-            {{ with .sublabel }}
-            <div class="text-sm opacity-70 leading-snug mt-1">{{ . }}</div>
-            {{ end }}
-          </div>
+        <a href="{{ .url }}" class="sd-home-data-card">
+          <span class="material-symbols-outlined sd-home-data-icon" style="color: {{ $color }};">
+            {{- if eq .icon "globe" }}public
+            {{- else if eq .icon "building" }}account_balance
+            {{- else if eq .icon "scale" }}gavel
+            {{- else if eq .icon "link" }}cable
+            {{- else if eq .icon "book" }}menu_book
+            {{- else if eq .icon "newspaper" }}article
+            {{- else if eq .icon "code" }}computer
+            {{- else if eq .icon "server" }}cloud
+            {{- else if eq .icon "rocket" }}rocket_launch
+            {{- else }}{{ .icon }}
+            {{- end -}}
+          </span>
+          <span class="sd-headline sd-home-data-value" style="color: {{ $color }};">{{ $count }}</span>
+          <span class="sd-home-data-label">{{ .label }}</span>
+          {{ with .sublabel }}<span class="sd-home-data-sublabel">{{ . }}</span>{{ end }}
         </a>
       {{ end }}
     </div>
-
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Rewrites all 7 active json-driven homepage partials from DaisyUI to the Stitch design system
- Wraps homepage in `<article class="sd-home section-design">` for CSS variable scoping
- Replaces DaisyUI `card`/`badge`/`btn` classes with `sd-*` prefixed Stitch classes
- Uses Material Symbols Outlined icons instead of inline SVGs
- Adds responsive breakpoints and dark mode via `--sd-*` CSS custom properties

### Partials redesigned
- `hero.html` — Blue gradient hero with badge (sd-events-hero pattern)
- `product-cards.html` — Tool cards with video/image previews
- `stats-grid.html` — Data category cards with Material icons
- `content-cards.html` — Blog/publication cards (reuses sd-blog-card pattern)
- `laws-list.html` — Law cards with type grouping
- `cta.html` — Gradient CTA with dot pattern overlay
- `projects-roadmap.html` — Coming soon cards with progress bars

### Previous PR
PR #37 modified `custom.html` which is not used (homepage uses `json-driven` layout). This PR fixes the correct files.

## Test plan
- [ ] Verify Hugo builds without errors via CI
- [ ] Check homepage renders correctly in light mode
- [ ] Check homepage renders correctly in dark mode
- [ ] Test responsive layout on mobile and desktop
- [ ] Verify all section links still work
- [ ] Compare visual consistency with other Stitch-redesigned pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)